### PR TITLE
Refactor scaling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy=0.16.1 pandas statsmodels netCDF4  cython pytest pip matplotlib basemap
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy=0.16.1 pandas netCDF4  cython pytest pip matplotlib basemap
   - source activate test-environment
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       pip install pybufr-ecmwf;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,13 @@
   New features are the possibility to use unrelated masking datasets and the
   possibility to temporally match any number of datasets and give them in sets
   of k datasets to multiple metric calculators.
+  
+* Changes in the scaling module, escpecially CDF matching. The new CDF scaling
+  module is more modular and does not make any assumptions about how unique the
+  percentiles for the CDF matching have to be. CDF matching now returns NaN
+  values if non unique percentiles are in the data. There are new functions that
+  rescale based on pre-calculated percentiles so these can be used if the user
+  wants to make sure that the percentiles are unique before matching.
 
 # v0.4.0, 2016-03-24
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ install:
   # target Python version and architecture
   - "conda update --yes conda"
   - "conda config --add channels https://conda.anaconda.org/ioos"
-  - "conda create -q --yes -n test python=%PYTHON_VERSION% numpy scipy pandas statsmodels netCDF4  cython pytest pip matplotlib pyproj basemap"
+  - "conda create -q --yes -n test python=%PYTHON_VERSION% numpy scipy pandas netCDF4  cython pytest pip matplotlib pyproj basemap"
   - "activate test"
   - "pip install pygeogrids"
   - "pip install pygeobase"

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -110,7 +110,6 @@ packages should be installed.
 * numpy >= 1.7.0 http://www.numpy.org/
 * pandas >= 0.11.0 http://pandas.pydata.org/
 * scipy >= 0.12.0 http://www.scipy.org/
-* statsmodels >= 0.4.3 http://statsmodels.sourceforge.net/
 * netCDF4 >= 1.0.1 https://pypi.python.org/pypi/netCDF4
 * pygeogrids https://pypi.python.org/pypi/pygeogrids
 * matplotlib >= 1.2.0 http://matplotlib.org/
@@ -166,7 +165,7 @@ Windows and Linux.
 
 .. code::
 
-   conda create -q --yes -n test python=2.7 numpy scipy pandas statsmodels netCDF4  cython pytest pip matplotlib pyproj
+   conda create -q --yes -n test python=2.7 numpy scipy pandas netCDF4  cython pytest pip matplotlib pyproj
    activate test
    pip install pygeogrids
    pip install pyresample

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy>=1.7.0
 scipy>=0.12
 pandas>=0.11.0,!=0.15.2
-statsmodels>=0.4.3
 matplotlib>=1.2.0
 netCDF4>=1.0.1
 pygeogrids

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -149,6 +149,18 @@ def test_add_scale(method):
                                df_scaled['y_scaled_' + method].values)
 
 
+def test_single_percentile_data():
+
+    n = 1000
+    x = np.arange(n, dtype=np.float)
+    y = np.ones(n)
+
+    s = scaling.lin_cdf_match(y, x)
+    nptest.assert_almost_equal(s, np.full_like(s, np.nan))
+    s = scaling.cdf_match(y, x)
+    nptest.assert_almost_equal(s, np.full_like(s, np.nan))
+
+
 def test_lin_cdf_match_stored_params():
     """
     Test scaling based on given percentiles.

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -128,21 +128,35 @@ def test_ascat_ismn_validation():
     vars_should = [u'n_obs', u'tau', u'gpi', u'RMSD', u'lon', u'p_tau',
                    u'BIAS', u'p_rho', u'rho', u'lat', u'R', u'p_R']
     n_obs_should = [360, 385, 1644, 1881, 1927, 479, 140, 251]
-    rho_should = np.array([0.54618734, 0.71739876, 0.62089276, 0.53246528,
-                           0.30299741, 0.69647062, 0.840593, 0.73913699],
+    rho_should = np.array([0.546187,
+                           0.717398,
+                           0.620892,
+                           0.532465,
+                           0.302997,
+                           0.694713,
+                           0.840592,
+                           0.742065],
                           dtype=np.float32)
 
-    rmsd_should = np.array([11.53626347, 7.54565048, 17.45193481, 21.19371414,
-                            14.24668026, 14.27493, 13.173215, 12.59192371],
+    rmsd_should = np.array([11.536263,
+                            7.545650,
+                            17.451935,
+                            21.193714,
+                            14.246680,
+                            14.494674,
+                            13.173215,
+                            12.903898],
                            dtype=np.float32)
     with nc.Dataset(results_fname) as results:
         assert sorted(results.variables.keys()) == sorted(vars_should)
         assert sorted(results.variables['n_obs'][:].tolist()) == sorted(
             n_obs_should)
         nptest.assert_allclose(sorted(rho_should),
-                               sorted(results.variables['rho'][:]))
+                               sorted(results.variables['rho'][:]),
+                               rtol=1e-4)
         nptest.assert_allclose(sorted(rmsd_should),
-                               sorted(results.variables['RMSD'][:]))
+                               sorted(results.variables['RMSD'][:]),
+                               rtol=1e-4)
 
 
 class TestDataset(object):


### PR DESCRIPTION
CDF matching is now based on one basic function that performs either
linear CDF matching or interpolates a spline of 5th order.

in_data and scale_to were renamed to src and ref

the statsmodels dependency is no longer needed.