### PR TITLE
Close netCDF file after each reading if read_bulk is not set.

### DIFF
--- a/pytesmo/io/sat/ascat.py
+++ b/pytesmo/io/sat/ascat.py
@@ -692,6 +692,9 @@ class AscatNetcdf(object):
 
         lon, lat = self.grid.gpi2lonlat(gpi)
 
+        if not self.read_bulk:
+            ncfile.close()
+
         return df, gpi, lon, lat, cell, topo, wetland, porosity
 
 


### PR DESCRIPTION
fix #93.

The segfault is not reliably reproduced so we can not write a test for
it but this change fixed it on the setup where it was first discovered.