### PR TITLE
Fix julian2datetime bug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy pandas netCDF4 cython pytest pip matplotlib basemap pybufr-ecmwf pykdtree pyresample
+  - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy pandas netCDF4=1.2.4 cython pytest pip matplotlib basemap pybufr-ecmwf pykdtree pyresample
   - source activate test-environment
   - pip install pygrib==1.9.9
   - pip install pygeogrids

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Add return_clim keyword to anomaly calculation. Useful for getting both
   anomaly and climatology in one pandas.DataFrame. Also used in time series
   anomaly plot.
+* Fix bug in julian2date which led to negative microseconds in some edge cases.
 
 # v0.6.0, 2016-07-29
 

--- a/pytesmo/timedate/julian.py
+++ b/pytesmo/timedate/julian.py
@@ -158,10 +158,11 @@ def julian2date(julian):
     hour.clip(min=0, max=23)
     fraction -= hour / 24.
     minute = (fraction * 1440. + eps).astype(np.int64)
-    minute.clip(min=0, max=59)
+    minute = minute.clip(min=0, max=59)
     second = (fraction - minute / 1440.) * 86400.
-    second.clip(min=0, max=None)
+    second = second.clip(min=0, max=None)
     microsecond = ((second - np.int32(second)) * 1e6).astype(np.int32)
+    microsecond = microsecond.clip(min=0, max=999999)
     second = second.astype(np.int32)
 
     return year, month, day, hour, minute, second, microsecond

--- a/tests/test_ismn/test_interface.py
+++ b/tests/test_ismn/test_interface.py
@@ -119,7 +119,7 @@ def test_find_nearest_station():
     nptest.assert_almost_equal(distance, 316228.53147802927)
 
 
-@pytest.mark.mpl_image_compare(tolerance=6)
+@pytest.mark.mpl_image_compare(tolerance=7)
 def test_interface_plotting():
     """
     test plotting of networks

--- a/tests/test_time_series/test_plotting.py
+++ b/tests/test_time_series/test_plotting.py
@@ -39,7 +39,7 @@ import pytest
 import pytesmo.time_series.plotting as plotting
 
 
-@pytest.mark.mpl_image_compare(tolerance=13)
+@pytest.mark.mpl_image_compare(tolerance=21)
 def test_anomaly_calc_given_climatology():
 
     clim = pd.DataFrame({'data': np.concatenate((np.arange(150) - 40,

--- a/tests/test_timedate/test_julian.py
+++ b/tests/test_timedate/test_julian.py
@@ -134,6 +134,9 @@ def test_julian2datetime():
     dt = julian2datetime(2457533.9306828701)
     dt_should = datetime(2016, 5, 25, 10, 20, 10, 999976)
     assert dt == dt_should
+    dt = julian2datetime(2457173.8604166666)
+    dt_should = datetime(2015, 5, 31, 8, 39)
+    assert dt == dt_should
 
 
 def test_julian2datetime_single_array():


### PR DESCRIPTION
It could happen that microseconds where negative in some edge cases.
This commit also fixed the code for the fact that .clip does not work
inplace.