### PR TITLE
Adapt ERS readers and validation framework to latest ascat package version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# v0.6.8, unreleased
+
+* Adapt valdiation framework examples to new ASCAT package version.
+* Adapt ERS reader to new ASCAT package version.
+* Make validation framework work with datasets that contain NaN columns.
+* Make validation framework work with pygeobase.object_base.TS objects and
+  subclasses.
+
 # v0.6.7, 2017-07-25
 
 * Add respect leap years option for climatology calculation.

--- a/docs/validation_framework.ipynb
+++ b/docs/validation_framework.ipynb
@@ -63,11 +63,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/cpa/.pyenv/versions/miniconda-3.16.0/envs/pytesmo/lib/python2.7/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.\n",
+      "  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import tempfile\n",
@@ -76,7 +85,7 @@
     "\n",
     "from datetime import datetime\n",
     "\n",
-    "from pytesmo.io.sat.ascat import AscatH25_SSM\n",
+    "from ascat.timeseries import AscatSsmCdr\n",
     "from pytesmo.io.ismn.interface import ISMN_Interface\n",
     "from pytesmo.validation_framework.validation import Validation\n",
     "from pytesmo.validation_framework.results_manager import netcdf_results_manager"
@@ -93,20 +102,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 19,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "ascat_data_folder = os.path.join('/media/sf_R', 'Datapool_processed', 'WARP', 'WARP5.5',\n",
-    "                                 'IRMA1_WARP5.5_P2', 'R1', '080_ssm', 'netcdf')\n",
+    "ascat_data_folder = os.path.join('/home', 'cpa', 'workspace', 'pytesmo',\n",
+    "                                 'tests', 'test-data', 'sat', 'ascat', 'netcdf', '55R22')\n",
     "ascat_grid_folder = os.path.join('/media/sf_R', 'Datapool_processed', 'WARP',\n",
     "                                 'ancillary', 'warp5_grid')\n",
+    "static_layers_folder = os.path.join('/home', 'cpa', 'workspace', 'pytesmo',\n",
+    "                                    'tests', 'test-data', 'sat',\n",
+    "                                    'h_saf', 'static_layer')\n",
     "\n",
-    "ascat_reader = AscatH25_SSM(ascat_data_folder, ascat_grid_folder)\n",
-    "ascat_reader.read_bulk = True\n",
-    "ascat_reader._load_grid_info()"
+    "\n",
+    "ascat_reader = AscatSsmCdr(ascat_data_folder, ascat_grid_folder,\n",
+    "                           static_layer_path=static_layers_folder)"
    ]
   },
   {
@@ -118,13 +130,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "ismn_data_folder = '/data/Development/python/workspace/pytesmo/tests/test-data/ismn/format_header_values/'\n",
+    "ismn_data_folder = '/data/Development/python/workspace/pytesmo/tests/test-data/ismn/multinetwork/header_values/'\n",
     "ismn_reader = ISMN_Interface(ismn_data_folder)"
    ]
   },
@@ -139,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -148,7 +160,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(0, 2.9567000000000001, 43.149999999999999)]\n"
+      "[(0, 102.13330000000001, 33.666600000000003), (1, 102.13330000000001, 33.883299999999998), (2, -120.9675, 38.430030000000002), (3, -120.78559, 38.149560000000001), (4, -120.80638999999999, 38.17353), (5, -105.417, 34.25), (6, -97.082999999999998, 37.133000000000003), (7, -86.549999999999997, 34.783000000000001)]\n"
      ]
     }
    ],
@@ -173,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -183,12 +195,12 @@
      "output_type": "stream",
      "text": [
       "                     soil moisture soil moisture_flag soil moisture_orig_flag\n",
-      "date                                                                         \n",
-      "2007-01-01 01:00:00          0.214                  U                       M\n",
-      "2007-01-01 02:00:00          0.214                  U                       M\n",
-      "2007-01-01 03:00:00          0.214                  U                       M\n",
-      "2007-01-01 04:00:00          0.214                  U                       M\n",
-      "2007-01-01 05:00:00          0.214                  U                       M\n"
+      "date_time                                                                    \n",
+      "2008-07-01 00:00:00           0.45                  U                       M\n",
+      "2008-07-01 01:00:00           0.45                  U                       M\n",
+      "2008-07-01 02:00:00           0.45                  U                       M\n",
+      "2008-07-01 03:00:00           0.45                  U                       M\n",
+      "2008-07-01 04:00:00           0.45                  U                       M\n"
      ]
     }
    ],
@@ -208,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 23,
    "metadata": {
     "collapsed": true
    },
@@ -232,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
@@ -274,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 25,
    "metadata": {
     "collapsed": true
    },
@@ -285,26 +297,120 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/cpa/.pyenv/versions/miniconda-3.16.0/envs/pytesmo/lib/python2.7/site-packages/pandas/core/reshape/merge.py:551: UserWarning: merging between different levels can give an unintended result (1 levels on the left, 2 on the right)\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/home/cpa/.pyenv/versions/miniconda-3.16.0/envs/pytesmo/lib/python2.7/site-packages/pandas/core/reshape/merge.py:551: UserWarning: merging between different levels can give an unintended result (2 levels on the left, 1 on the right)\n",
+      "  warnings.warn(msg, UserWarning)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.34625292], dtype=float32),\n",
-      "                                                'R': array([ 0.46913505], dtype=float32),\n",
-      "                                                'RMSD': array([ 9.74285984], dtype=float32),\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04330891], dtype=float32),\n",
+      "                                                'R': array([ 0.7128256], dtype=float32),\n",
+      "                                                'RMSD': array([ 7.72966719], dtype=float32),\n",
       "                                                'gpi': array([0], dtype=int32),\n",
-      "                                                'lat': array([ 43.15]),\n",
-      "                                                'lon': array([ 2.9567]),\n",
-      "                                                'n_obs': array([31], dtype=int32),\n",
-      "                                                'p_R': array([ 0.00776013], dtype=float32),\n",
-      "                                                'p_rho': array([ 0.00407545], dtype=float32),\n",
+      "                                                'lat': array([ 33.6666]),\n",
+      "                                                'lon': array([ 102.1333]),\n",
+      "                                                'n_obs': array([384], dtype=int32),\n",
+      "                                                'p_R': array([ 0.], dtype=float32),\n",
+      "                                                'p_rho': array([ 0.], dtype=float32),\n",
       "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.50121337], dtype=float32),\n",
+      "                                                'rho': array([ 0.70022893], dtype=float32),\n",
+      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([ 0.237454], dtype=float32),\n",
+      "                                                'R': array([ 0.4996146], dtype=float32),\n",
+      "                                                'RMSD': array([ 11.58347607], dtype=float32),\n",
+      "                                                'gpi': array([1], dtype=int32),\n",
+      "                                                'lat': array([ 33.8833]),\n",
+      "                                                'lon': array([ 102.1333]),\n",
+      "                                                'n_obs': array([357], dtype=int32),\n",
+      "                                                'p_R': array([  6.12721281e-24], dtype=float32),\n",
+      "                                                'p_rho': array([  2.47165110e-28], dtype=float32),\n",
+      "                                                'p_tau': array([ nan], dtype=float32),\n",
+      "                                                'rho': array([ 0.53934574], dtype=float32),\n",
+      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.63301021], dtype=float32),\n",
+      "                                                'R': array([ 0.78071409], dtype=float32),\n",
+      "                                                'RMSD': array([ 14.57700157], dtype=float32),\n",
+      "                                                'gpi': array([2], dtype=int32),\n",
+      "                                                'lat': array([ 38.43003]),\n",
+      "                                                'lon': array([-120.9675]),\n",
+      "                                                'n_obs': array([482], dtype=int32),\n",
+      "                                                'p_R': array([ 0.], dtype=float32),\n",
+      "                                                'p_rho': array([ 0.], dtype=float32),\n",
+      "                                                'p_tau': array([ nan], dtype=float32),\n",
+      "                                                'rho': array([ 0.69356072], dtype=float32),\n",
+      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-1.9682411], dtype=float32),\n",
+      "                                                'R': array([ 0.79960084], dtype=float32),\n",
+      "                                                'RMSD': array([ 13.06224251], dtype=float32),\n",
+      "                                                'gpi': array([3], dtype=int32),\n",
+      "                                                'lat': array([ 38.14956]),\n",
+      "                                                'lon': array([-120.78559]),\n",
+      "                                                'n_obs': array([141], dtype=int32),\n",
+      "                                                'p_R': array([  1.38538225e-32], dtype=float32),\n",
+      "                                                'p_rho': array([  4.62621032e-39], dtype=float32),\n",
+      "                                                'p_tau': array([ nan], dtype=float32),\n",
+      "                                                'rho': array([ 0.84189808], dtype=float32),\n",
+      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.21823417], dtype=float32),\n",
+      "                                                'R': array([ 0.80635566], dtype=float32),\n",
+      "                                                'RMSD': array([ 12.90389824], dtype=float32),\n",
+      "                                                'gpi': array([4], dtype=int32),\n",
+      "                                                'lat': array([ 38.17353]),\n",
+      "                                                'lon': array([-120.80639]),\n",
+      "                                                'n_obs': array([251], dtype=int32),\n",
+      "                                                'p_R': array([ 0.], dtype=float32),\n",
+      "                                                'p_rho': array([  4.20389539e-45], dtype=float32),\n",
+      "                                                'p_tau': array([ nan], dtype=float32),\n",
+      "                                                'rho': array([ 0.74206454], dtype=float32),\n",
+      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.14228749], dtype=float32),\n",
+      "                                                'R': array([ 0.50703788], dtype=float32),\n",
+      "                                                'RMSD': array([ 14.24668026], dtype=float32),\n",
+      "                                                'gpi': array([5], dtype=int32),\n",
+      "                                                'lat': array([ 34.25]),\n",
+      "                                                'lon': array([-105.417]),\n",
+      "                                                'n_obs': array([1927], dtype=int32),\n",
+      "                                                'p_R': array([ 0.], dtype=float32),\n",
+      "                                                'p_rho': array([  3.32948515e-42], dtype=float32),\n",
+      "                                                'p_tau': array([ nan], dtype=float32),\n",
+      "                                                'rho': array([ 0.30299741], dtype=float32),\n",
+      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([ 0.2600247], dtype=float32),\n",
+      "                                                'R': array([ 0.53643185], dtype=float32),\n",
+      "                                                'RMSD': array([ 21.19682884], dtype=float32),\n",
+      "                                                'gpi': array([6], dtype=int32),\n",
+      "                                                'lat': array([ 37.133]),\n",
+      "                                                'lon': array([-97.083]),\n",
+      "                                                'n_obs': array([1887], dtype=int32),\n",
+      "                                                'p_R': array([ 0.], dtype=float32),\n",
+      "                                                'p_rho': array([ 0.], dtype=float32),\n",
+      "                                                'p_tau': array([ nan], dtype=float32),\n",
+      "                                                'rho': array([ 0.53143877], dtype=float32),\n",
+      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04437888], dtype=float32),\n",
+      "                                                'R': array([ 0.6058206], dtype=float32),\n",
+      "                                                'RMSD': array([ 17.3883934], dtype=float32),\n",
+      "                                                'gpi': array([7], dtype=int32),\n",
+      "                                                'lat': array([ 34.783]),\n",
+      "                                                'lon': array([-86.55]),\n",
+      "                                                'n_obs': array([1652], dtype=int32),\n",
+      "                                                'p_R': array([ 0.], dtype=float32),\n",
+      "                                                'p_rho': array([ 0.], dtype=float32),\n",
+      "                                                'p_tau': array([ nan], dtype=float32),\n",
+      "                                                'rho': array([ 0.62204134], dtype=float32),\n",
       "                                                'tau': array([ nan], dtype=float32)}}\n"
      ]
     }
@@ -330,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -339,18 +445,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "n_obs [31]\n",
-      "tau [ nan]\n",
-      "gpi [0]\n",
-      "RMSD [ 9.74285984]\n",
-      "lon [ 2.9567]\n",
-      "p_tau [ nan]\n",
-      "BIAS [-0.34625292]\n",
-      "p_rho [ 0.00407545]\n",
-      "rho [ 0.50121337]\n",
-      "lat [ 43.15]\n",
-      "R [ 0.46913505]\n",
-      "p_R [ 0.00776013]\n"
+      "n_obs [ 384  357  482  141  251 1927 1887 1652]\n",
+      "tau [ nan  nan  nan  nan  nan  nan  nan  nan]\n",
+      "gpi [0 1 2 3 4 5 6 7]\n",
+      "RMSD [  7.72966719  11.58347607  14.57700157  13.06224251  12.90389824\n",
+      "  14.24668026  21.19682884  17.3883934 ]\n",
+      "lon [ 102.1333   102.1333  -120.9675  -120.78559 -120.80639 -105.417    -97.083\n",
+      "  -86.55   ]\n",
+      "p_tau [ nan  nan  nan  nan  nan  nan  nan  nan]\n",
+      "BIAS [-0.04330891  0.237454   -0.63301021 -1.9682411  -0.21823417 -0.14228749\n",
+      "  0.2600247  -0.04437888]\n",
+      "p_rho [  0.00000000e+00   2.47165110e-28   0.00000000e+00   4.62621032e-39\n",
+      "   4.20389539e-45   3.32948515e-42   0.00000000e+00   0.00000000e+00]\n",
+      "rho [ 0.70022893  0.53934574  0.69356072  0.84189808  0.74206454  0.30299741\n",
+      "  0.53143877  0.62204134]\n",
+      "lat [ 33.6666   33.8833   38.43003  38.14956  38.17353  34.25     37.133\n",
+      "  34.783  ]\n",
+      "R [ 0.7128256   0.4996146   0.78071409  0.79960084  0.80635566  0.50703788\n",
+      "  0.53643185  0.6058206 ]\n",
+      "p_R [  0.00000000e+00   6.12721281e-24   0.00000000e+00   1.38538225e-32\n",
+      "   0.00000000e+00   0.00000000e+00   0.00000000e+00   0.00000000e+00]\n"
      ]
     }
    ],
@@ -374,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "metadata": {
     "collapsed": true
    },
@@ -433,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -442,12 +556,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "date\n",
-      "2007-01-01 01:00:00    False\n",
-      "2007-01-01 02:00:00    False\n",
-      "2007-01-01 03:00:00    False\n",
-      "2007-01-01 04:00:00    False\n",
-      "2007-01-01 05:00:00    False\n",
+      "date_time\n",
+      "2008-07-01 00:00:00    False\n",
+      "2008-07-01 01:00:00    False\n",
+      "2008-07-01 02:00:00    False\n",
+      "2008-07-01 03:00:00    False\n",
+      "2008-07-01 04:00:00    False\n",
       "Name: soil moisture, dtype: bool\n"
      ]
     }
@@ -458,6 +572,15 @@
     "ds_mask = MaskingAdapter(ismn_reader, '<', 0.2)\n",
     "print ds_mask.read_ts(ids[0])['soil moisture'].head()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/validation_framework.rst
+++ b/docs/validation_framework.rst
@@ -115,10 +115,11 @@ perform a comparison between ASCAT and ISMN data.
     
     from datetime import datetime
     
-    from ascat import AscatH25_SSM
+    from ascat.timeseries import AscatSsmCdr
     from pytesmo.io.ismn.interface import ISMN_Interface
     from pytesmo.validation_framework.validation import Validation
     from pytesmo.validation_framework.results_manager import netcdf_results_manager
+
 
 First we initialize the data readers that we want to use. In this case
 the ASCAT soil moisture time series and in situ data from the ISMN.
@@ -127,20 +128,23 @@ Initialize ASCAT reader
 
 .. code:: python
 
-    ascat_data_folder = os.path.join('/media/sf_R', 'Datapool_processed', 'WARP', 'WARP5.5',
-                                     'IRMA1_WARP5.5_P2', 'R1', '080_ssm', 'netcdf')
+    ascat_data_folder = os.path.join('/home', 'cpa', 'workspace', 'pytesmo',
+                                     'tests', 'test-data', 'sat', 'ascat', 'netcdf', '55R22')
     ascat_grid_folder = os.path.join('/media/sf_R', 'Datapool_processed', 'WARP',
                                      'ancillary', 'warp5_grid')
+    static_layers_folder = os.path.join('/home', 'cpa', 'workspace', 'pytesmo',
+                                        'tests', 'test-data', 'sat',
+                                        'h_saf', 'static_layer')
     
-    ascat_reader = AscatH25_SSM(ascat_data_folder, ascat_grid_folder)
-    ascat_reader.read_bulk = True
-    ascat_reader._load_grid_info()
+    
+    ascat_reader = AscatSsmCdr(ascat_data_folder, ascat_grid_folder,
+                               static_layer_path=static_layers_folder)
 
 Initialize ISMN reader
 
 .. code:: python
 
-    ismn_data_folder = '/data/Development/python/workspace/pytesmo/tests/test-data/ismn/format_header_values/'
+    ismn_data_folder = '/data/Development/python/workspace/pytesmo/tests/test-data/ismn/multinetwork/header_values/'
     ismn_reader = ISMN_Interface(ismn_data_folder)
 
 The validation is run based on jobs. A job consists of at least three
@@ -166,7 +170,7 @@ the parallel processing!
 
 .. parsed-literal::
 
-    [(0, 2.9567000000000001, 43.149999999999999)]
+    [(0, 102.13330000000001, 33.666600000000003), (1, 102.13330000000001, 33.883299999999998), (2, -120.9675, 38.430030000000002), (3, -120.78559, 38.149560000000001), (4, -120.80638999999999, 38.17353), (5, -105.417, 34.25), (6, -97.082999999999998, 37.133000000000003), (7, -86.549999999999997, 34.783000000000001)]
 
 
 For this small test dataset it is only one job
@@ -184,12 +188,12 @@ framework can go through the jobs and read the correct time series.
 .. parsed-literal::
 
                          soil moisture soil moisture_flag soil moisture_orig_flag
-    date                                                                         
-    2007-01-01 01:00:00          0.214                  U                       M
-    2007-01-01 02:00:00          0.214                  U                       M
-    2007-01-01 03:00:00          0.214                  U                       M
-    2007-01-01 04:00:00          0.214                  U                       M
-    2007-01-01 05:00:00          0.214                  U                       M
+    date_time                                                                    
+    2008-07-01 00:00:00           0.45                  U                       M
+    2008-07-01 01:00:00           0.45                  U                       M
+    2008-07-01 02:00:00           0.45                  U                       M
+    2008-07-01 03:00:00           0.45                  U                       M
+    2008-07-01 04:00:00           0.45                  U                       M
 
 
 Initialize the Validation class
@@ -285,17 +289,101 @@ processing!
 
 .. parsed-literal::
 
-    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.34625292], dtype=float32),
-                                                    'R': array([ 0.46913505], dtype=float32),
-                                                    'RMSD': array([ 9.74285984], dtype=float32),
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04330891], dtype=float32),
+                                                    'R': array([ 0.7128256], dtype=float32),
+                                                    'RMSD': array([ 7.72966719], dtype=float32),
                                                     'gpi': array([0], dtype=int32),
-                                                    'lat': array([ 43.15]),
-                                                    'lon': array([ 2.9567]),
-                                                    'n_obs': array([31], dtype=int32),
-                                                    'p_R': array([ 0.00776013], dtype=float32),
-                                                    'p_rho': array([ 0.00407545], dtype=float32),
+                                                    'lat': array([ 33.6666]),
+                                                    'lon': array([ 102.1333]),
+                                                    'n_obs': array([384], dtype=int32),
+                                                    'p_R': array([ 0.], dtype=float32),
+                                                    'p_rho': array([ 0.], dtype=float32),
                                                     'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.50121337], dtype=float32),
+                                                    'rho': array([ 0.70022893], dtype=float32),
+                                                    'tau': array([ nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([ 0.237454], dtype=float32),
+                                                    'R': array([ 0.4996146], dtype=float32),
+                                                    'RMSD': array([ 11.58347607], dtype=float32),
+                                                    'gpi': array([1], dtype=int32),
+                                                    'lat': array([ 33.8833]),
+                                                    'lon': array([ 102.1333]),
+                                                    'n_obs': array([357], dtype=int32),
+                                                    'p_R': array([  6.12721281e-24], dtype=float32),
+                                                    'p_rho': array([  2.47165110e-28], dtype=float32),
+                                                    'p_tau': array([ nan], dtype=float32),
+                                                    'rho': array([ 0.53934574], dtype=float32),
+                                                    'tau': array([ nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.63301021], dtype=float32),
+                                                    'R': array([ 0.78071409], dtype=float32),
+                                                    'RMSD': array([ 14.57700157], dtype=float32),
+                                                    'gpi': array([2], dtype=int32),
+                                                    'lat': array([ 38.43003]),
+                                                    'lon': array([-120.9675]),
+                                                    'n_obs': array([482], dtype=int32),
+                                                    'p_R': array([ 0.], dtype=float32),
+                                                    'p_rho': array([ 0.], dtype=float32),
+                                                    'p_tau': array([ nan], dtype=float32),
+                                                    'rho': array([ 0.69356072], dtype=float32),
+                                                    'tau': array([ nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-1.9682411], dtype=float32),
+                                                    'R': array([ 0.79960084], dtype=float32),
+                                                    'RMSD': array([ 13.06224251], dtype=float32),
+                                                    'gpi': array([3], dtype=int32),
+                                                    'lat': array([ 38.14956]),
+                                                    'lon': array([-120.78559]),
+                                                    'n_obs': array([141], dtype=int32),
+                                                    'p_R': array([  1.38538225e-32], dtype=float32),
+                                                    'p_rho': array([  4.62621032e-39], dtype=float32),
+                                                    'p_tau': array([ nan], dtype=float32),
+                                                    'rho': array([ 0.84189808], dtype=float32),
+                                                    'tau': array([ nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.21823417], dtype=float32),
+                                                    'R': array([ 0.80635566], dtype=float32),
+                                                    'RMSD': array([ 12.90389824], dtype=float32),
+                                                    'gpi': array([4], dtype=int32),
+                                                    'lat': array([ 38.17353]),
+                                                    'lon': array([-120.80639]),
+                                                    'n_obs': array([251], dtype=int32),
+                                                    'p_R': array([ 0.], dtype=float32),
+                                                    'p_rho': array([  4.20389539e-45], dtype=float32),
+                                                    'p_tau': array([ nan], dtype=float32),
+                                                    'rho': array([ 0.74206454], dtype=float32),
+                                                    'tau': array([ nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.14228749], dtype=float32),
+                                                    'R': array([ 0.50703788], dtype=float32),
+                                                    'RMSD': array([ 14.24668026], dtype=float32),
+                                                    'gpi': array([5], dtype=int32),
+                                                    'lat': array([ 34.25]),
+                                                    'lon': array([-105.417]),
+                                                    'n_obs': array([1927], dtype=int32),
+                                                    'p_R': array([ 0.], dtype=float32),
+                                                    'p_rho': array([  3.32948515e-42], dtype=float32),
+                                                    'p_tau': array([ nan], dtype=float32),
+                                                    'rho': array([ 0.30299741], dtype=float32),
+                                                    'tau': array([ nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([ 0.2600247], dtype=float32),
+                                                    'R': array([ 0.53643185], dtype=float32),
+                                                    'RMSD': array([ 21.19682884], dtype=float32),
+                                                    'gpi': array([6], dtype=int32),
+                                                    'lat': array([ 37.133]),
+                                                    'lon': array([-97.083]),
+                                                    'n_obs': array([1887], dtype=int32),
+                                                    'p_R': array([ 0.], dtype=float32),
+                                                    'p_rho': array([ 0.], dtype=float32),
+                                                    'p_tau': array([ nan], dtype=float32),
+                                                    'rho': array([ 0.53143877], dtype=float32),
+                                                    'tau': array([ nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04437888], dtype=float32),
+                                                    'R': array([ 0.6058206], dtype=float32),
+                                                    'RMSD': array([ 17.3883934], dtype=float32),
+                                                    'gpi': array([7], dtype=int32),
+                                                    'lat': array([ 34.783]),
+                                                    'lon': array([-86.55]),
+                                                    'n_obs': array([1652], dtype=int32),
+                                                    'p_R': array([ 0.], dtype=float32),
+                                                    'p_rho': array([ 0.], dtype=float32),
+                                                    'p_tau': array([ nan], dtype=float32),
+                                                    'rho': array([ 0.62204134], dtype=float32),
                                                     'tau': array([ nan], dtype=float32)}}
 
 
@@ -325,18 +413,26 @@ stored netCDF file which is named after the dictionary key:
 
 .. parsed-literal::
 
-    n_obs [31]
-    tau [ nan]
-    gpi [0]
-    RMSD [ 9.74285984]
-    lon [ 2.9567]
-    p_tau [ nan]
-    BIAS [-0.34625292]
-    p_rho [ 0.00407545]
-    rho [ 0.50121337]
-    lat [ 43.15]
-    R [ 0.46913505]
-    p_R [ 0.00776013]
+    n_obs [ 384  357  482  141  251 1927 1887 1652]
+    tau [ nan  nan  nan  nan  nan  nan  nan  nan]
+    gpi [0 1 2 3 4 5 6 7]
+    RMSD [  7.72966719  11.58347607  14.57700157  13.06224251  12.90389824
+      14.24668026  21.19682884  17.3883934 ]
+    lon [ 102.1333   102.1333  -120.9675  -120.78559 -120.80639 -105.417    -97.083
+      -86.55   ]
+    p_tau [ nan  nan  nan  nan  nan  nan  nan  nan]
+    BIAS [-0.04330891  0.237454   -0.63301021 -1.9682411  -0.21823417 -0.14228749
+      0.2600247  -0.04437888]
+    p_rho [  0.00000000e+00   2.47165110e-28   0.00000000e+00   4.62621032e-39
+       4.20389539e-45   3.32948515e-42   0.00000000e+00   0.00000000e+00]
+    rho [ 0.70022893  0.53934574  0.69356072  0.84189808  0.74206454  0.30299741
+      0.53143877  0.62204134]
+    lat [ 33.6666   33.8833   38.43003  38.14956  38.17353  34.25     37.133
+      34.783  ]
+    R [ 0.7128256   0.4996146   0.78071409  0.79960084  0.80635566  0.50703788
+      0.53643185  0.6058206 ]
+    p_R [  0.00000000e+00   6.12721281e-24   0.00000000e+00   1.38538225e-32
+       0.00000000e+00   0.00000000e+00   0.00000000e+00   0.00000000e+00]
 
 
 Parallel processing
@@ -407,11 +503,12 @@ given threshold.
 
 .. parsed-literal::
 
-    date
-    2007-01-01 01:00:00    False
-    2007-01-01 02:00:00    False
-    2007-01-01 03:00:00    False
-    2007-01-01 04:00:00    False
-    2007-01-01 05:00:00    False
+    date_time
+    2008-07-01 00:00:00    False
+    2008-07-01 01:00:00    False
+    2008-07-01 02:00:00    False
+    2008-07-01 03:00:00    False
+    2008-07-01 04:00:00    False
     Name: soil moisture, dtype: bool
+
 

--- a/pytesmo/temporal_matching.py
+++ b/pytesmo/temporal_matching.py
@@ -105,10 +105,10 @@ def df_match(reference, *args, **kwds):
             arg_matched.loc[invalid_dist] = np.nan
 
         if "dropna" in kwds and kwds['dropna']:
-            arg_matched = arg_matched.dropna()
+            arg_matched = arg_matched.dropna(how='all')
 
         if "dropduplicates" in kwds and kwds['dropduplicates']:
-            arg_matched = arg_matched.dropna()
+            arg_matched = arg_matched.dropna(how='all')
             g = arg_matched.groupby('merge_key')
             min_dists = g.distance.apply(lambda x: x.abs().idxmin())
             arg_matched = arg_matched.ix[min_dists]

--- a/pytesmo/validation_framework/data_manager.py
+++ b/pytesmo/validation_framework/data_manager.py
@@ -251,8 +251,8 @@ class DataManager(object):
         try:
             func = getattr(ds['class'], self.read_ts_names[name])
             data_df = func(*args, **ds['kwargs'])
-            if type(data_df) is TS:
-                data_df = TS.data
+            if type(data_df) is TS or issubclass(type(data_df), TS):
+                data_df = data_df.data
         except IOError:
             warnings.warn(
                 "IOError while reading dataset {} with args {:}".format(name,

--- a/pytesmo/validation_framework/temporal_matchers.py
+++ b/pytesmo/validation_framework/temporal_matchers.py
@@ -71,7 +71,7 @@ class BasicTemporalMatching(object):
             match = match.drop('distance', axis=1)
             matched_data = matched_data.join(match)
 
-        return matched_data.dropna()
+        return matched_data.dropna(how='all')
 
     def combinatory_matcher(self, df_dict, refkey, n=2):
         """

--- a/pytesmo/validation_framework/validation.py
+++ b/pytesmo/validation_framework/validation.py
@@ -468,6 +468,8 @@ class Validation(object):
 
         # extract only the relevant columns from matched DataFrame
         data = data[[x for x in result_tuple]]
+        # drop values if one column is NaN
+        data = data.dropna()
         return data
 
     def get_processing_jobs(self):

--- a/tests/test_sat/test_ers.py
+++ b/tests/test_sat/test_ers.py
@@ -50,57 +50,58 @@ class TestERSNetCDF(unittest.TestCase):
                                             '..', 'test-data', 'sat',
                                             'ascat', 'netcdf', 'grid')
 
+        self.static_layers_folder = os.path.join(os.path.dirname(__file__),
+                                                 '..', 'test-data', 'sat',
+                                                 'h_saf', 'static_layer')
         # init the ERS_SSM reader with the paths
         self.ers_SSM_reader = ers.ERS_SSM(
-            self.ers_folder, self.ers_grid_folder)
+            self.ers_folder, self.ers_grid_folder,
+            static_layer_path=self.static_layers_folder)
 
     def test_read_ssm(self):
 
         gpi = 2329253
-        result = self.ers_SSM_reader.read_ssm(gpi, absolute_values=True)
+        result = self.ers_SSM_reader.read(gpi, absolute_sm=True)
         assert result.gpi == gpi
         np.testing.assert_approx_equal(
             result.longitude, 14.28413, significant=4)
         np.testing.assert_approx_equal(
             result.latitude, 45.698074, significant=4)
 
-        assert list(result.data.columns) == ['orbit_dir', 'proc_flag',
-                                             'sm', 'sm_noise',
-                                             'sm_por_gldas',
-                                             'sm_noise_por_gldas',
-                                             'sm_por_hwsd',
-                                             'sm_noise_por_hwsd',
-                                             'frozen_prob',
-                                             'snow_prob']
+        assert list(result.data.columns.values) == ['orbit_dir', 'proc_flag',
+                                                    'sm', 'sm_noise',
+                                                    'snow_prob',
+                                                    'frozen_prob',
+                                                    'abs_sm_gldas',
+                                                    'abs_sm_noise_gldas',
+                                                    'abs_sm_hwsd',
+                                                    'abs_sm_noise_hwsd']
         assert len(result.data) == 478
         assert result.data.ix[15].name == datetime(1992, 1, 27, 21, 11, 42, 55)
         assert result.data.ix[15]['sm'] == 57
         assert result.data.ix[15]['sm_noise'] == 7
-        assert result.data.ix[15]['frozen_prob'] == 18
-        assert result.data.ix[15]['snow_prob'] == 0
         assert result.data.ix[15]['orbit_dir'].decode('utf-8') == 'A'
         assert result.data.ix[15]['proc_flag'] == 0
         np.testing.assert_approx_equal(
-            result.data.ix[15]['sm_por_gldas'], 0.3090667, significant=6)
+            result.data.ix[15]['abs_sm_gldas'], 0.30780001223, significant=6)
 
         np.testing.assert_approx_equal(
-            result.data.ix[15]['sm_noise_por_gldas'], 0.03795555,
+            result.data.ix[15]['abs_sm_noise_gldas'], 0.03780000150,
             significant=6)
 
         np.testing.assert_approx_equal(
-            result.data.ix[15]['sm_por_hwsd'], 0.2452333, significant=6)
+            result.data.ix[15]['abs_sm_hwsd'], 0.245100004076, significant=6)
         np.testing.assert_approx_equal(
-            result.data.ix[15]['sm_noise_por_hwsd'], 0.03011637, significant=6)
+            result.data.ix[15]['abs_sm_noise_hwsd'], 0.0301000005006, significant=6)
         assert result.topo_complex == 14
         assert result.wetland_frac == 0
         np.testing.assert_approx_equal(
-            result.porosity_gldas, 0.54222, significant=5)
+            result.porosity_gldas, 0.540000, significant=5)
         np.testing.assert_approx_equal(
-            result.porosity_hwsd, 0.430234, significant=5)
+            result.porosity_hwsd, 0.430000, significant=5)
 
     def test_neighbor_search(self):
 
-        self.ers_SSM_reader._load_grid_info()
         gpi, distance = self.ers_SSM_reader.grid.find_nearest_gpi(3.25, 46.13)
         assert gpi == 2346869
         np.testing.assert_approx_equal(distance, 2267.42, significant=2)

--- a/tests/test_validation_framwork/test_validation.py
+++ b/tests/test_validation_framwork/test_validation.py
@@ -47,7 +47,7 @@ from pytesmo.validation_framework.data_manager import DataManager
 
 from datetime import datetime
 
-from ascat import AscatH25_SSM
+from ascat.timeseries import AscatSsmCdr
 from pytesmo.io.ismn.interface import ISMN_Interface
 from pytesmo.validation_framework.validation import Validation
 from pytesmo.validation_framework.validation import args_to_iterable
@@ -68,9 +68,13 @@ def test_ascat_ismn_validation():
     ascat_grid_folder = os.path.join(os.path.dirname(__file__), '..', 'test-data',
                                      'sat', 'ascat', 'netcdf', 'grid')
 
-    ascat_reader = AscatH25_SSM(ascat_data_folder, ascat_grid_folder)
+    static_layers_folder = os.path.join(os.path.dirname(__file__),
+                                        '..', 'test-data', 'sat',
+                                        'h_saf', 'static_layer')
+
+    ascat_reader = AscatSsmCdr(ascat_data_folder, ascat_grid_folder,
+                               static_layer_path=static_layers_folder)
     ascat_reader.read_bulk = True
-    ascat_reader._load_grid_info()
 
     # Initialize ISMN reader
 
@@ -130,26 +134,16 @@ def test_ascat_ismn_validation():
 
     vars_should = [u'n_obs', u'tau', u'gpi', u'RMSD', u'lon', u'p_tau',
                    u'BIAS', u'p_rho', u'rho', u'lat', u'R', u'p_R']
-    n_obs_should = [360, 385, 1644, 1881, 1927, 479, 140, 251]
-    rho_should = np.array([0.546187,
-                           0.717398,
-                           0.620892,
-                           0.532465,
-                           0.302997,
-                           0.694713,
-                           0.840592,
-                           0.742065],
-                          dtype=np.float32)
+    n_obs_should = [384,  357,  482,  141,  251, 1927, 1887, 1652]
+    rho_should = np.array([0.70022893, 0.53934574,
+                           0.69356072, 0.84189808,
+                           0.74206454, 0.30299741,
+                           0.53143877, 0.62204134], dtype=np.float32)
 
-    rmsd_should = np.array([11.536263,
-                            7.545650,
-                            17.451935,
-                            21.193714,
-                            14.246680,
-                            14.494674,
-                            13.173215,
-                            12.903898],
-                           dtype=np.float32)
+    rmsd_should = np.array([7.72966719, 11.58347607,
+                            14.57700157, 13.06224251,
+                            12.90389824, 14.24668026,
+                            21.19682884, 17.3883934], dtype=np.float32)
     with nc.Dataset(results_fname) as results:
         assert sorted(results.variables.keys()) == sorted(vars_should)
         assert sorted(results.variables['n_obs'][:].tolist()) == sorted(


### PR DESCRIPTION
- Base ERS reader on latest ASCAT package use H-SAF static layers.
- Validation framework can now deal with columns that contain a lot of NaN values but are of no interest during the validation by only dropping NaN values when the columns of interest are already selected.