### PR TITLE
Linear regression scaling with nans

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+unreleased 
+===================
+
+- Split linreg scaling function to determine and apply corrections separately
+
 v0.6.10, 2018-04-09
 ===================
 
@@ -10,7 +15,6 @@ v0.6.9, 2018-02-06
 - Add extendent collocation metric
 - Fix initial value for exponential filter
 - Fix #123
-
 
 v0.6.8, 2017-08-29
 ==================

--- a/pytesmo/scaling.py
+++ b/pytesmo/scaling.py
@@ -172,8 +172,10 @@ def linreg(src, ref):
         dataset scaled using linear regression
     """
 
+    df = pd.DataFrame(data={'src': src, 'ref': ref}).dropna()
+
     slope, intercept, r_value, p_value, std_err = stats.linregress(
-        src, ref)
+        df.src, df.ref)
 
     return np.abs(slope) * src + intercept
 

--- a/pytesmo/scaling.py
+++ b/pytesmo/scaling.py
@@ -155,6 +155,54 @@ def min_max(src, ref):
             (np.max(ref) - np.min(ref)) + np.min(ref))
 
 
+def linreg_stored_params(src, slope, intercept):
+    '''
+    Scale the input data with passed correction values
+
+    Parameters
+    ----------
+    src : numpy.array
+        Candidate values, that are scaled
+    slope : float
+        Multiplicative correction value
+    intercept : float
+        Additive correction value
+
+    Returns
+    -------
+    src_scaled : numpy.array
+        The scaled input values
+    '''
+
+    return np.abs(slope) * src + intercept
+
+
+def linreg_params(src, ref):
+    '''
+    Calculate additive and multiplicative correction parameters
+    based on linear regression models.
+
+    Parameters
+    ----------
+    src: numpy.array
+        Candidate data (to which the corrections apply)
+    ref : numpy.array
+        Reference data (which candidate is scaled to)
+
+    Returns
+    -------
+    slope : float
+        Multiplicative correction value
+    intercept : float
+        Additive correction value
+    '''
+
+    slope, intercept, r_value, p_value, std_err = stats.linregress(src, ref)
+
+    return slope, intercept
+
+
+
 def linreg(src, ref):
     """
     scales the input datasets using linear regression
@@ -172,12 +220,8 @@ def linreg(src, ref):
         dataset scaled using linear regression
     """
 
-    df = pd.DataFrame(data={'src': src, 'ref': ref}).dropna()
-
-    slope, intercept, r_value, p_value, std_err = stats.linregress(
-        df.src, df.ref)
-
-    return np.abs(slope) * src + intercept
+    slope, intercept = linreg_params(src, ref)
+    return linreg_stored_params(src, slope, intercept)
 
 
 def mean_std(src, ref):

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -153,13 +153,15 @@ def test_linreg_with_nan():
 
     x[0:10] = np.nan
 
-    df = pd.DataFrame({'x': x, 'y': y}, columns=['x', 'y'])
-    df_scaled = scaling.scale(df,
-                              method='linreg',
-                              reference_index=0)
+    df = pd.DataFrame(data={'x': x, 'y': y})
 
-    nptest.assert_almost_equal(df_scaled.loc[10:, 'x'].values,
-                               df_scaled.loc[10:, 'y'].values)
+    slope, inter = scaling.linreg_params(df.dropna()['x'].values, df.dropna()['y'].values)
+    df['x'] = scaling.linreg_stored_params(df['x'].values, slope, inter)
+
+    nptest.assert_almost_equal(df.loc[10:, 'x'].values,
+                               df.loc[10:, 'y'].values)
+
+    assert(df.index.size == n)
 
 
 def test_single_percentile_data():

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -146,6 +146,21 @@ def test_add_scale(method):
     nptest.assert_almost_equal(df_scaled['x'].values,
                                df_scaled['y_scaled_' + method].values)
 
+def test_linreg_with_nan():
+    n = 1000
+    x = np.arange(float(n))
+    y = np.arange(float(n)) * 0.5
+
+    x[0:10] = np.nan
+
+    df = pd.DataFrame({'x': x, 'y': y}, columns=['x', 'y'])
+    df_scaled = scaling.scale(df,
+                              method='linreg',
+                              reference_index=0)
+
+    nptest.assert_almost_equal(df_scaled.loc[10:, 'x'].values,
+                               df_scaled.loc[10:, 'y'].values)
+
 
 def test_single_percentile_data():
 


### PR DESCRIPTION
In this implementation, when there are nans in the src or ref series, these lines are removed from the data frame (pandas dropna) (as stats.linreg needs arrays of equal lengths), when the correction params are found (slope, inter) they are applied back to the full array (until now stats.linreg raised an error). Bias correction will probably be worse if there are a lot if nans, but the function should not fail anymore.
@cpaulik : You think this is ok?