### PR TITLE
Add masking helpers to validation framework

### DIFF
--- a/docs/validation_framework.ipynb
+++ b/docs/validation_framework.ipynb
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,9 +121,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/space/tools/miniconda3/envs/pytesmo/lib/python2.7/site-packages/ascat/timeseries.py:128: UserWarning: WARNING: valid_range not used since it\n",
+      "cannot be safely cast to variable data type\n",
+      "  land_gp = np.where(grid_nc.variables['land_flag'][:] == 1)[0]\n"
+     ]
+    }
+   ],
    "source": [
     "ascat_data_folder = os.path.join(testdata_folder,\n",
     "                                 'sat/ascat/netcdf/55R22')\n",
@@ -147,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -207,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -245,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,9 +333,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/space/tools/miniconda3/envs/pytesmo/lib/python2.7/site-packages/pandas/core/reshape/merge.py:558: UserWarning: merging between different levels can give an unintended result (1 levels on the left, 2 on the right)\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/space/tools/miniconda3/envs/pytesmo/lib/python2.7/site-packages/pandas/core/reshape/merge.py:558: UserWarning: merging between different levels can give an unintended result (2 levels on the left, 1 on the right)\n",
+      "  warnings.warn(msg, UserWarning)\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -457,49 +477,105 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "n_obs [141 482 251 1652 1887 1927 357 384 141 482 251 1652 1887 1927 357 384]\n",
-      "tau [nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan]\n",
-      "gpi [0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7]\n",
+      "n_obs [141 482 251 1652 1887 1927 357 384 141 482 251 1652 1887 1927 357 384 141\n",
+      " 482 141 482 251 1652 1887 1927 357 384 141 482 251 1652 1887 1927 357 384\n",
+      " 141 482 251 1652 1887 1927 357 384]\n",
+      "tau [nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan\n",
+      " nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan\n",
+      " nan nan nan nan nan nan]\n",
+      "gpi [0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2\n",
+      " 3 4 5 6 7]\n",
       "RMSD [13.06224250793457 14.577001571655273 12.903898239135742 17.38839340209961\n",
+      " 21.196828842163086 14.24668025970459 11.583476066589355\n",
+      " 7.7296671867370605 13.06224250793457 14.577001571655273\n",
+      " 12.903898239135742 17.38839340209961 21.196828842163086 14.24668025970459\n",
+      " 11.583476066589355 7.7296671867370605 13.06224250793457\n",
+      " 14.577001571655273 13.06224250793457 14.577001571655273\n",
+      " 12.903898239135742 17.38839340209961 21.196828842163086 14.24668025970459\n",
+      " 11.583476066589355 7.7296671867370605 13.06224250793457\n",
+      " 14.577001571655273 12.903898239135742 17.38839340209961\n",
       " 21.196828842163086 14.24668025970459 11.583476066589355\n",
       " 7.7296671867370605 13.06224250793457 14.577001571655273\n",
       " 12.903898239135742 17.38839340209961 21.196828842163086 14.24668025970459\n",
       " 11.583476066589355 7.7296671867370605]\n",
       "lon [-120.78559 -120.9675 -120.80639 -86.55 -97.083 -105.417 102.1333 102.1333\n",
-      " -120.78559 -120.9675 -120.80639 -86.55 -97.083 -105.417 102.1333 102.1333]\n",
-      "p_tau [nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan]\n",
+      " -120.78559 -120.9675 -120.80639 -86.55 -97.083 -105.417 102.1333 102.1333\n",
+      " -120.78559 -120.9675 -120.78559 -120.9675 -120.80639 -86.55 -97.083\n",
+      " -105.417 102.1333 102.1333 -120.78559 -120.9675 -120.80639 -86.55 -97.083\n",
+      " -105.417 102.1333 102.1333 -120.78559 -120.9675 -120.80639 -86.55 -97.083\n",
+      " -105.417 102.1333 102.1333]\n",
+      "p_tau [nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan\n",
+      " nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan\n",
+      " nan nan nan nan nan nan]\n",
       "BIAS [-1.9682410955429077 -0.63301020860672 -0.21823416650295258\n",
       " -0.04437888041138649 0.26002469658851624 -0.1422874927520752\n",
       " 0.23745399713516235 -0.043308909982442856 -1.9682410955429077\n",
       " -0.63301020860672 -0.21823416650295258 -0.04437888041138649\n",
       " 0.26002469658851624 -0.1422874927520752 0.23745399713516235\n",
-      " -0.043308909982442856]\n",
+      " -0.043308909982442856 -1.9682410955429077 -0.63301020860672\n",
+      " -1.9682410955429077 -0.63301020860672 -0.21823416650295258\n",
+      " -0.04437888041138649 0.26002469658851624 -0.1422874927520752\n",
+      " 0.23745399713516235 -0.043308909982442856 -1.9682410955429077\n",
+      " -0.63301020860672 -0.21823416650295258 -0.04437888041138649\n",
+      " 0.26002469658851624 -0.1422874927520752 0.23745399713516235\n",
+      " -0.043308909982442856 -1.9682410955429077 -0.63301020860672\n",
+      " -0.21823416650295258 -0.04437888041138649 0.26002469658851624\n",
+      " -0.1422874927520752 0.23745399713516235 -0.043308909982442856]\n",
       "p_rho [4.6262103163618786e-39 0.0 4.203895392974451e-45 0.0 0.0\n",
       " 3.3294851512357654e-42 2.471651101555352e-28 0.0 4.6262103163618786e-39\n",
       " 0.0 4.203895392974451e-45 0.0 0.0 3.3294851512357654e-42\n",
+      " 2.471651101555352e-28 0.0 4.6262103163618786e-39 0.0\n",
+      " 4.6262103163618786e-39 0.0 4.203895392974451e-45 0.0 0.0\n",
+      " 3.3294851512357654e-42 2.471651101555352e-28 0.0 4.6262103163618786e-39\n",
+      " 0.0 4.203895392974451e-45 0.0 0.0 3.3294851512357654e-42\n",
+      " 2.471651101555352e-28 0.0 4.6262103163618786e-39 0.0\n",
+      " 4.203895392974451e-45 0.0 0.0 3.3294851512357654e-42\n",
       " 2.471651101555352e-28 0.0]\n",
       "rho [0.8418980836868286 0.6935607194900513 0.7420645356178284\n",
       " 0.6220413446426392 0.5314387679100037 0.3029974102973938\n",
       " 0.5393457412719727 0.7002289295196533 0.8418980836868286\n",
       " 0.6935607194900513 0.7420645356178284 0.6220413446426392\n",
       " 0.5314387679100037 0.3029974102973938 0.5393457412719727\n",
-      " 0.7002289295196533]\n",
+      " 0.7002289295196533 0.8418980836868286 0.6935607194900513\n",
+      " 0.8418980836868286 0.6935607194900513 0.7420645356178284\n",
+      " 0.6220413446426392 0.5314387679100037 0.3029974102973938\n",
+      " 0.5393457412719727 0.7002289295196533 0.8418980836868286\n",
+      " 0.6935607194900513 0.7420645356178284 0.6220413446426392\n",
+      " 0.5314387679100037 0.3029974102973938 0.5393457412719727\n",
+      " 0.7002289295196533 0.8418980836868286 0.6935607194900513\n",
+      " 0.7420645356178284 0.6220413446426392 0.5314387679100037\n",
+      " 0.3029974102973938 0.5393457412719727 0.7002289295196533]\n",
       "lat [38.14956 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956\n",
-      " 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666]\n",
+      " 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956 38.43003\n",
+      " 38.14956 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956\n",
+      " 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956 38.43003\n",
+      " 38.17353 34.783 37.133 34.25 33.8833 33.6666]\n",
       "R [0.7996008396148682 0.7807140946388245 0.8063556551933289\n",
       " 0.6058205962181091 0.5364318490028381 0.507037878036499\n",
       " 0.4996145963668823 0.71282559633255 0.7996008396148682 0.7807140946388245\n",
       " 0.8063556551933289 0.6058205962181091 0.5364318490028381\n",
-      " 0.507037878036499 0.4996145963668823 0.71282559633255]\n",
+      " 0.507037878036499 0.4996145963668823 0.71282559633255 0.7996008396148682\n",
+      " 0.7807140946388245 0.7996008396148682 0.7807140946388245\n",
+      " 0.8063556551933289 0.6058205962181091 0.5364318490028381\n",
+      " 0.507037878036499 0.4996145963668823 0.71282559633255 0.7996008396148682\n",
+      " 0.7807140946388245 0.8063556551933289 0.6058205962181091\n",
+      " 0.5364318490028381 0.507037878036499 0.4996145963668823 0.71282559633255\n",
+      " 0.7996008396148682 0.7807140946388245 0.8063556551933289\n",
+      " 0.6058205962181091 0.5364318490028381 0.507037878036499\n",
+      " 0.4996145963668823 0.71282559633255]\n",
       "p_R [1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0 6.12721281290096e-24 0.0\n",
-      " 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0 6.12721281290096e-24 0.0]\n"
+      " 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0 6.12721281290096e-24 0.0\n",
+      " 1.3853822467078656e-32 0.0 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0\n",
+      " 6.12721281290096e-24 0.0 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0\n",
+      " 6.12721281290096e-24 0.0 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0\n",
+      " 6.12721281290096e-24 0.0]\n"
      ]
     }
    ],
@@ -523,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,33 +646,67 @@
     "### Masking adapter\n",
     "\n",
     "To easily transform an existing dataset into a masking dataset `pytesmo` offers a adapter class that calls the\n",
-    "`read_ts` method of an existing dataset and performs the masking based on an operator and a given threshold."
+    "`read_ts` method of an existing dataset and creates a masking dataset based on an operator, a given threshold, and (optionally) a column name."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "date_time\n",
-      "2012-12-14 19:00:00    False\n",
-      "2012-12-14 20:00:00    False\n",
-      "2012-12-14 21:00:00    False\n",
-      "2012-12-14 22:00:00    False\n",
-      "2012-12-14 23:00:00    False\n",
-      "Name: soil moisture, dtype: bool\n"
+      "                     soil moisture\n",
+      "date_time                         \n",
+      "2012-12-14 19:00:00          False\n",
+      "2012-12-14 20:00:00          False\n",
+      "2012-12-14 21:00:00          False\n",
+      "2012-12-14 22:00:00          False\n",
+      "2012-12-14 23:00:00          False\n"
      ]
     }
    ],
    "source": [
     "from pytesmo.validation_framework.adapters import MaskingAdapter\n",
     "\n",
-    "ds_mask = MaskingAdapter(ismn_reader, '<', 0.2)\n",
-    "print ds_mask.read_ts(ids[0])['soil moisture'].head()"
+    "ds_mask = MaskingAdapter(ismn_reader, '<', 0.2, 'soil moisture')\n",
+    "print ds_mask.read_ts(ids[0]).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Self-masking adapter\n",
+    "`pytesmo` also has a class that masks a dataset \"on-the-fly\", based on one of the columns it contains and an operator and a threshold. In contrast to the masking adapter mentioned above, the output of the self-masking adapter is the masked data, not the the mask. The self-masking adapter wraps a data reader, which must have a `read_ts` or `read` method. Calling its `read_ts`/`read` method will return the masked data - more precisely a DataFrame with only rows where the masking condition is true."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                     soil moisture soil moisture_flag  soil moisture_orig_flag\n",
+      "date_time                                                                     \n",
+      "2013-08-21 22:00:00         0.1682                  U                        0\n",
+      "2013-08-21 23:00:00         0.1665                  U                        0\n",
+      "2013-08-22 00:00:00         0.1682                  U                        0\n",
+      "2013-08-22 01:00:00         0.1615                  U                        0\n",
+      "2013-08-22 02:00:00         0.1631                  U                        0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pytesmo.validation_framework.adapters import SelfMaskingAdapter\n",
+    "\n",
+    "ds_mask = SelfMaskingAdapter(ismn_reader, '<', 0.2, 'soil moisture')\n",
+    "print ds_mask.read_ts(ids[0]).head()"
    ]
   }
  ],

--- a/docs/validation_framework.ipynb
+++ b/docs/validation_framework.ipynb
@@ -1,149 +1,86 @@
 {
  "cells": [
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The pytesmo validation framework\n",
-    "================================\n",
+    "# The pytesmo validation framework\n",
     "\n",
-    "The pytesmo validation framework takes care of iterating over datasets,\n",
-    "spatial and temporal matching as well as sclaing. It uses metric\n",
-    "calculators to then calculate metrics that are returned to the user.\n",
-    "There are several metrics calculators included in pytesmo but new ones\n",
-    "can be added simply by writing a new class.\n",
+    "The pytesmo validation framework takes care of iterating over datasets, spatial and temporal matching as well as\n",
+    "scaling. It uses metric calculators to then calculate metrics that are returned to the user. There are several\n",
+    "metrics calculators included in pytesmo but new ones can be added simply.\n",
     "\n",
-    "Overview\n",
-    "--------\n",
+    "## Overview\n",
     "\n",
-    "How does the validation framework work? It makes these assumptions about\n",
-    "the used datasets:\n",
+    "How does the validation framework work? It makes these assumptions about the used datasets:\n",
     "\n",
-    "-  The dataset readers that are used have a ``read_ts`` method that can\n",
-    "   be called either by a grid point index (gpi) which can be any\n",
-    "   indicator that identifies a certain grid point or by using longitude\n",
-    "   and latitude. This means that both call signatures ``read_ts(gpi)``\n",
-    "   and ``read_ts(lon, lat)`` must be valid. Please check the\n",
-    "   `pygeobase <https://github.com/TUW-GEO/pygeobase>`__ documentation\n",
-    "   for more details on how a fully compatible dataset class should look.\n",
-    "   But a simple ``read_ts`` method should do for the validation\n",
-    "   framework. This assumption can be relaxed by using the\n",
-    "   ``read_ts_names`` keyword in the\n",
-    "   pytesmo.validation\\_framework.data\\_manager.DataManager class.\n",
-    "-  The ``read_ts`` method returns a pandas.DataFrame time series.\n",
-    "-  Ideally the datasets classes also have a ``grid`` attribute that is a\n",
-    "   `pygeogrids <http://pygeogrids.readthedocs.org/en/latest/>`__ grid.\n",
-    "   This makes the calculation of lookup tables easily possible and the\n",
-    "   nearest neighbor search faster.\n",
+    "- The dataset readers that are used have a `read_ts` method that can be called either by a grid point index (gpi)\n",
+    "  which can be any indicator that identifies a certain grid point or by using longitude and latitude. This means that\n",
+    "  both call signatures `read_ts(gpi)` and `read_ts(lon, lat)` must be valid. Please check the\n",
+    "  [pygeobase](https://github.com/TUW-GEO/pygeobase) documentation for more details on how a fully compatible dataset\n",
+    "  class should look. But a simple `read_ts` method should do for the validation framework. This assumption can be\n",
+    "  relaxed by using the `read_ts_names` keyword in the pytesmo.validation_framework.data_manager.DataManager class.\n",
+    "- The `read_ts` method returns a pandas.DataFrame time series.\n",
+    "- Ideally the datasets classes also have a `grid` attribute that is a\n",
+    "  [pygeogrids](http://pygeogrids.readthedocs.org/en/latest/) grid. This makes the calculation of lookup tables easily\n",
+    "  possible and the nearest neighbor search faster.\n",
     "\n",
-    "Fortunately these assumptions are true about the dataset readers\n",
-    "included in pytesmo.\n",
+    "Fortunately these assumptions are true about the dataset readers included in pytesmo. \n",
     "\n",
-    "It also makes a few assumptions about how to perform a validation. For a\n",
-    "comparison study it is often necessary to choose a spatial reference\n",
-    "grid, a temporal reference and a scaling or data space reference.\n",
+    "It also makes a few assumptions about how to perform a validation. For a comparison study it is often necessary to\n",
+    "choose a spatial reference grid, a temporal reference and a scaling or data space reference.\n",
     "\n",
-    "Spatial reference\n",
-    "~~~~~~~~~~~~~~~~~\n",
+    "### Spatial reference\n",
+    "The spatial reference is the one to which all the other datasets are matched spatially. Often through nearest\n",
+    "neighbor search. The validation framework uses grid points of the dataset specified as the spatial reference to\n",
+    "spatially match all the other datasets with nearest neighbor search. Other, more sophisticated spatial matching\n",
+    "algorithms are not implemented at the moment. If you need a more complex spatial matching then a preprocessing of\n",
+    "the data is the only option at the moment.\n",
     "\n",
-    "The spatial reference is the one to which all the other datasets are\n",
-    "matched spatially. Often through nearest neighbor search. The validation\n",
-    "framework uses grid points of the dataset specified as the spatial\n",
-    "reference to spatially match all the other datasets with nearest\n",
-    "neighbor search. Other, more sophisticated spatial matching algorithms\n",
-    "are not implemented at the moment. If you need a more complex spatial\n",
-    "matching then a preprocessing of the data is the only option at the\n",
-    "moment.\n",
+    "### Temporal reference\n",
+    "The temporal reference is the dataset to which the other dataset are temporally matched. That means that the\n",
+    "nearest observation to the reference timestamps in a certain time window is chosen for each comparison dataset.\n",
+    "This is by default done by the temporal matching module included in pytesmo. How many datasets should be matched to\n",
+    "the reference dataset at once can be configured, we will cover how to do this later.\n",
     "\n",
-    "Temporal reference\n",
-    "~~~~~~~~~~~~~~~~~~\n",
+    "### Data space reference\n",
+    "It is often necessary to bring all the datasets into a common data space by using. Scaling is often used for that\n",
+    "and pytesmo offers a choice of several scaling algorithms (e.g. CDF matching, min-max scaling, mean-std scaling,\n",
+    "triple collocation based scaling). The data space reference can also be chosen independently from the other two\n",
+    "references.\n",
     "\n",
-    "The temporal reference is the dataset to which the other dataset are\n",
-    "temporally matched. That means that the nearest observation to the\n",
-    "reference timestamps in a certain time window is chosen for each\n",
-    "comparison dataset. This is by default done by the temporal matching\n",
-    "module included in pytesmo. How many datasets should be matched to the\n",
-    "reference dataset at once can be configured, we will cover how to do\n",
-    "this later.\n",
+    "## Data Flow\n",
     "\n",
-    "Data space reference\n",
-    "~~~~~~~~~~~~~~~~~~~~\n",
-    "\n",
-    "It is often necessary to bring all the datasets into a common data space\n",
-    "by using scaling. Pytesmo offers a choice of several scaling algorithms\n",
-    "(e.g. CDF matching, min-max scaling, mean-std scaling, triple\n",
-    "collocation based scaling). The data space reference can also be chosen\n",
-    "independently from the other two references. New scaling methods can be\n",
-    "implemented by writing a scaler class. An example of a scaler class can\n",
-    "be found in the\n",
-    ":py:class:`pytesmo.validation_framework.data_scalers.DefaultScaler`.\n",
-    "\n",
-    "Data Flow\n",
-    "---------\n",
-    "\n",
-    "After it is initialized, the validation framework works through the\n",
-    "following steps:\n",
+    "After it is initialized, the validation framework works through the following steps:\n",
     "\n",
     "1. Read all the datasets for a certain job (gpi, lon, lat)\n",
-    "2. Read all the masking datasets if any\n",
+    "2. Read all the masking dataset if any\n",
     "3. Mask the temporal reference dataset using the masking data\n",
-    "4. Temporally match all the chosen combinations of temporal reference\n",
-    "   and other datasets\n",
-    "5. Scale all datasets into the data space of the data space reference,\n",
-    "   if scaling is activated\n",
-    "6. Turn the temporally matched time series over to the metric\n",
-    "   calculators\n",
-    "7. Get the calculated metrics from the metric calculators\n",
-    "8. Put all the metrics into a dictionary by dataset combination and\n",
-    "   return them.\n",
+    "4. Temporally match all the chosen combinations of temporal reference and other datasets\n",
+    "5. Turn the temporally matched time series over to the metric calculators\n",
+    "6. Get the calculated metrics from the metric calculators\n",
+    "7. Put all the metrics into a dictionary by dataset combination and return them.\n",
     "\n",
-    "Masking datasets\n",
-    "----------------\n",
+    "## Masking datasets\n",
+    "Masking datasets can be used if the datasets that are compared do not contain the necessary information to mask\n",
+    " them. For example we might want to use modelled soil temperature data to mask our soil moisture observations\n",
+    "before comparing them. To be able to do that we just need a Dataset that returns a pandas.DataFrame with one column\n",
+    " of boolean data type. Everywhere where the masking dataset is `True` the data will be masked.\n",
     "\n",
-    "Masking datasets can be used if the the datasets that are compared do\n",
-    "not contain the necessary information to mask them. For example we might\n",
-    "want to use modelled soil temperature data to mask our soil moisture\n",
-    "observations before comparing them. To be able to do that we just need a\n",
-    "Dataset that returns a pandas.DataFrame with one column of boolean data\n",
-    "type. Everywhere where the masking dataset is ``True`` the data will be\n",
-    "masked.\n",
+    "Let's look at a first example.\n",
     "\n",
-    "Let's look at a first example.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Example soil moisture validation: ASCAT - ISMN"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This example shows how to setup the pytesmo validation framework to perform a comparison between ASCAT and ISMN data. "
+    "## Example soil moisture validation: ASCAT - ISMN\n",
+    "\n",
+    "This example shows how to setup the pytesmo validation framework to perform a comparison between ASCAT and ISMN data. \n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/cpa/.pyenv/versions/miniconda-3.16.0/envs/pytesmo/lib/python2.7/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.\n",
-      "  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
-    "import tempfile\n",
     "\n",
     "import pytesmo.validation_framework.metric_calculators as metrics_calculators\n",
     "\n",
@@ -159,30 +96,46 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First we initialize the data readers that we want to use. In this case the ASCAT soil moisture time series and in situ data from the ISMN. \n",
+    "You need the test data from https://github.com/TUW-GEO/pytesmo-test-data for this example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testdata_folder = '/pytesmo/testdata'\n",
+    "output_folder = '/pytesmo/code/examples/output'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we initialize the data readers that we want to use. In this case the ASCAT soil moisture time series and in\n",
+    "situ data from the ISMN.\n",
     "\n",
     "Initialize ASCAT reader"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "ascat_data_folder = os.path.join('/home', 'cpa', 'workspace', 'pytesmo',\n",
-    "                                 'tests', 'test-data', 'sat', 'ascat', 'netcdf', '55R22')\n",
-    "ascat_grid_folder = os.path.join('/media/sf_R', 'Datapool_processed', 'WARP',\n",
-    "                                 'ancillary', 'warp5_grid')\n",
-    "static_layers_folder = os.path.join('/home', 'cpa', 'workspace', 'pytesmo',\n",
-    "                                    'tests', 'test-data', 'sat',\n",
-    "                                    'h_saf', 'static_layer')\n",
-    "\n",
+    "ascat_data_folder = os.path.join(testdata_folder,\n",
+    "                                 'sat/ascat/netcdf/55R22')\n",
+    "ascat_grid_folder = os.path.join(testdata_folder,\n",
+    "                                 'sat/ascat/netcdf/grid')\n",
+    "static_layers_folder = os.path.join(testdata_folder,\n",
+    "                                    'sat/h_saf/static_layer')\n",
     "\n",
     "ascat_reader = AscatSsmCdr(ascat_data_folder, ascat_grid_folder,\n",
-    "                           static_layer_path=static_layers_folder)"
+    "                           grid_filename='TUW_WARP5_grid_info_2_1.nc',\n",
+    "                           static_layer_path=static_layers_folder)\n",
+    "ascat_reader.read_bulk = True"
    ]
   },
   {
@@ -194,13 +147,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "ismn_data_folder = '/data/Development/python/workspace/pytesmo/tests/test-data/ismn/multinetwork/header_values/'\n",
+    "ismn_data_folder = os.path.join(testdata_folder,\n",
+    "                                 'ismn/multinetwork/header_values')\n",
+    "\n",
     "ismn_reader = ISMN_Interface(ismn_data_folder)"
    ]
   },
@@ -208,23 +161,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The validation is run based on jobs. A job consists of at least three lists or numpy arrays specifing the grid point index, its latitude and longitude. In the case of the ISMN we can use the `dataset_ids` that identify every time series in the downloaded ISMN data as our grid point index. We can then get longitude and latitude from the metadata of the dataset.\n",
+    "The validation is run based on jobs. A job consists of at least three lists or numpy arrays specifing the grid\n",
+    "point index, its latitude and longitude. In the case of the ISMN we can use the `dataset_ids` that identify every\n",
+    "time series in the downloaded ISMN data as our grid point index. We can then get longitude and latitude from the\n",
+    "metadata of the dataset.\n",
     "\n",
     "**DO NOT CHANGE** the name ***jobs*** because it will be searched during the parallel processing!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[(0, 102.13330000000001, 33.666600000000003), (1, 102.13330000000001, 33.883299999999998), (2, -120.9675, 38.430030000000002), (3, -120.78559, 38.149560000000001), (4, -120.80638999999999, 38.17353), (5, -105.417, 34.25), (6, -97.082999999999998, 37.133000000000003), (7, -86.549999999999997, 34.783000000000001)]\n"
+      "Jobs (gpi, lon, lat):\n",
+      "[(0, -120.78559, 38.14956), (1, -120.9675, 38.43003), (2, -120.80639, 38.17353), (3, -86.55, 34.783), (4, -97.083, 37.133), (5, -105.417, 34.25), (6, 102.1333, 33.8833), (7, 102.1333, 33.6666)]\n"
      ]
     }
    ],
@@ -235,7 +190,9 @@
     "for idx in ids:\n",
     "    metadata = ismn_reader.metadata[idx]\n",
     "    jobs.append((idx, metadata['longitude'], metadata['latitude']))\n",
-    "print jobs"
+    "\n",
+    "print(\"Jobs (gpi, lon, lat):\")\n",
+    "print(jobs)"
    ]
   },
   {
@@ -244,33 +201,34 @@
    "source": [
     "For this small test dataset it is only one job\n",
     "\n",
-    "It is important here that the ISMN reader has a read_ts function that works by just using the `dataset_id`. In this way the validation framework can go through the jobs and read the correct time series."
+    "It is important here that the ISMN reader has a read_ts function that works by just using the `dataset_id`. In this\n",
+    " way the validation framework can go through the jobs and read the correct time series."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                     soil moisture soil moisture_flag soil moisture_orig_flag\n",
-      "date_time                                                                    \n",
-      "2008-07-01 00:00:00           0.45                  U                       M\n",
-      "2008-07-01 01:00:00           0.45                  U                       M\n",
-      "2008-07-01 02:00:00           0.45                  U                       M\n",
-      "2008-07-01 03:00:00           0.45                  U                       M\n",
-      "2008-07-01 04:00:00           0.45                  U                       M\n"
+      "ISMN data example:\n",
+      "                     soil moisture soil moisture_flag  soil moisture_orig_flag\n",
+      "date_time                                                                     \n",
+      "2012-12-14 19:00:00         0.3166                  U                        0\n",
+      "2012-12-14 20:00:00         0.3259                  U                        0\n",
+      "2012-12-14 21:00:00         0.3259                  U                        0\n",
+      "2012-12-14 22:00:00         0.3263                  U                        0\n",
+      "2012-12-14 23:00:00         0.3263                  U                        0\n"
      ]
     }
    ],
    "source": [
     "data = ismn_reader.read_ts(ids[0])\n",
-    "print data.head()"
+    "print('ISMN data example:')\n",
+    "print(data.head())"
    ]
   },
   {
@@ -279,256 +237,269 @@
    "source": [
     "## Initialize the Validation class\n",
     "\n",
-    "The Validation class is the heart of the validation framwork. It contains the information about which datasets to read using which arguments or keywords and if they are spatially compatible. It also contains the settings about which metric calculators to use and how to perform the scaling into the reference data space. It is initialized in the following way:"
+    "The Validation class is the heart of the validation framwork. It contains the information about which datasets to\n",
+    "read using which arguments or keywords and if they are spatially compatible. It also contains the settings about\n",
+    "which metric calculators to use and how to perform the scaling into the reference data space. It is initialized in\n",
+    "the following way:\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "datasets = {'ISMN': {'class': ismn_reader, \n",
-    "                     'columns': ['soil moisture']},\n",
-    "            'ASCAT': {'class': ascat_reader, 'columns': ['sm'],\n",
-    "                      'kwargs': {'mask_frozen_prob': 80,\n",
-    "                                 'mask_snow_prob': 80,\n",
-    "                                 'mask_ssf': True}}\n",
-    "           }"
+    "datasets = {\n",
+    "    'ISMN': {\n",
+    "        'class': ismn_reader,\n",
+    "        'columns': ['soil moisture']\n",
+    "    },\n",
+    "    'ASCAT': {\n",
+    "        'class': ascat_reader,\n",
+    "        'columns': ['sm'],\n",
+    "        'kwargs': {'mask_frozen_prob': 80,\n",
+    "                   'mask_snow_prob': 80,\n",
+    "                   'mask_ssf': True}\n",
+    "    }}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The datasets dictionary contains all the information about the datasets to read. The `class` is the dataset class to use which we have already initialized. The `columns` key describes which columns of the dataset interest us for validation. This a mandatory field telling the framework which other columns to ignore. In this case the columns `soil moisture_flag` and `soil moisture_orig_flag` will be ignored by the ISMN reader. We can also specify additional keywords that should be given to the `read_ts` method of the dataset reader. In this case we want the ASCAT reader to mask the ASCAT soil moisture using the included frozen and snow probabilities as well as the SSF. There are also other keys that can be used here. Please see the documentation for explanations."
+    "The datasets dictionary contains all the information about the datasets to read. The `class` is the dataset class\n",
+    "to use which we have already initialized. The `columns` key describes which columns of the dataset interest us for\n",
+    "validation. This a mandatory field telling the framework which other columns to ignore. In this case the columns\n",
+    "`soil moisture_flag` and `soil moisture_orig_flag` will be ignored by the ISMN reader. We can also specify\n",
+    "additional keywords that should be given to the `read_ts` method of the dataset reader. In this case we want the\n",
+    "ASCAT reader to mask the ASCAT soil moisture using the included frozen and snow probabilities as well as the SSF.\n",
+    "There are also other keys that can be used here. Please see the documentation for explanations."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 21,
+   "metadata": {},
    "outputs": [],
    "source": [
     "period = [datetime(2007, 1, 1), datetime(2014, 12, 31)]\n",
     "basic_metrics = metrics_calculators.BasicMetrics(other_name='k1')\n",
     "\n",
     "process = Validation(\n",
-    "    datasets, 'ISMN', {(2, 2): basic_metrics.calc_metrics},\n",
+    "    datasets, 'ISMN',\n",
     "    temporal_ref='ASCAT',\n",
     "    scaling='lin_cdf_match',\n",
     "    scaling_ref='ASCAT',   \n",
-    "    period=period)\n"
+    "    metrics_calculators={(2, 2): basic_metrics.calc_metrics},\n",
+    "    period=period)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "During the initialization of the Validation class we can also tell it other things that it needs to know. In this case it uses the datasets we have specified earlier. The spatial reference is the `'ISMN'` dataset which is the second argument. The third argument looks a little bit strange so let's look at it in more detail.\n",
+    "During the initialization of the Validation class we can also tell it other things that it needs to know. In this\n",
+    "case it uses the datasets we have specified earlier. The spatial reference is the `'ISMN'` dataset which is the\n",
+    "second argument. The 'metrics_calculators' argument looks a little bit strange so let's look at it in more detail.\n",
     "\n",
-    "It is a dictionary with a tuple as the key and a function as the value. The key tuple `(n, k)` has the following meaning: `n` datasets are temporally matched together and then given in sets of `k` columns to the metric calculator. The metric calculator then gets a DataFrame with the columns ['ref', 'k1', 'k2' ...] and so on depending on the value of k. The value of `(2, 2)` makes sense here since we only have two datasets and all our metrics also take two inputs. \n",
+    "It is a dictionary with a tuple as the key and a function as the value. The key tuple `(n, k)` has the following\n",
+    "meaning: `n` datasets are temporally matched together and then given in sets of `k` columns to the metric\n",
+    "calculator. The metric calculator then gets a DataFrame with the columns ['ref', 'k1', 'k2' ...] and so on\n",
+    "depending on the value of k. The value of `(2, 2)` makes sense here since we only have two datasets and all our\n",
+    "metrics also take two inputs.\n",
     "\n",
-    "This can be used in more complex scenarios to e.g. have three input datasets that are all temporally matched together and then combinations of two input datasets are given to one metric calculator while all three datasets are given to another metric calculator. This could look like this:\n",
+    "This can be used in more complex scenarios to e.g. have three input datasets that are all temporally matched\n",
+    "together and then combinations of two input datasets are given to one metric calculator while all three datasets\n",
+    "are given to another metric calculator. This could look like this:\n",
     "\n",
     "```python\n",
     "{ (3 ,2): metric_calc,\n",
     "  (3, 3): triple_collocation}\n",
-    "```"
+    "```\n",
+    "\n",
+    "Create the variable ***save_path*** which is a string representing the path where the results will be saved.\n",
+    "**DO NOT CHANGE** the name ***save_path*** because it will be searched during the parallel processing!"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 23,
    "metadata": {},
-   "source": [
-    "Create the variable ***save_path*** which is a string representing the path where the results will be saved. **DO NOT CHANGE** the name ***save_path*** because it will be searched during the parallel processing!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "save_path = tempfile.mkdtemp()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "collapsed": false
-   },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/cpa/.pyenv/versions/miniconda-3.16.0/envs/pytesmo/lib/python2.7/site-packages/pandas/core/reshape/merge.py:551: UserWarning: merging between different levels can give an unintended result (1 levels on the left, 2 on the right)\n",
-      "  warnings.warn(msg, UserWarning)\n",
-      "/home/cpa/.pyenv/versions/miniconda-3.16.0/envs/pytesmo/lib/python2.7/site-packages/pandas/core/reshape/merge.py:551: UserWarning: merging between different levels can give an unintended result (2 levels on the left, 1 on the right)\n",
-      "  warnings.warn(msg, UserWarning)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04330891], dtype=float32),\n",
-      "                                                'R': array([ 0.7128256], dtype=float32),\n",
-      "                                                'RMSD': array([ 7.72966719], dtype=float32),\n",
-      "                                                'gpi': array([0], dtype=int32),\n",
-      "                                                'lat': array([ 33.6666]),\n",
-      "                                                'lon': array([ 102.1333]),\n",
-      "                                                'n_obs': array([384], dtype=int32),\n",
-      "                                                'p_R': array([ 0.], dtype=float32),\n",
-      "                                                'p_rho': array([ 0.], dtype=float32),\n",
-      "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.70022893], dtype=float32),\n",
-      "                                                'tau': array([ nan], dtype=float32)}}\n",
-      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([ 0.237454], dtype=float32),\n",
-      "                                                'R': array([ 0.4996146], dtype=float32),\n",
-      "                                                'RMSD': array([ 11.58347607], dtype=float32),\n",
-      "                                                'gpi': array([1], dtype=int32),\n",
-      "                                                'lat': array([ 33.8833]),\n",
-      "                                                'lon': array([ 102.1333]),\n",
-      "                                                'n_obs': array([357], dtype=int32),\n",
-      "                                                'p_R': array([  6.12721281e-24], dtype=float32),\n",
-      "                                                'p_rho': array([  2.47165110e-28], dtype=float32),\n",
-      "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.53934574], dtype=float32),\n",
-      "                                                'tau': array([ nan], dtype=float32)}}\n",
-      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.63301021], dtype=float32),\n",
-      "                                                'R': array([ 0.78071409], dtype=float32),\n",
-      "                                                'RMSD': array([ 14.57700157], dtype=float32),\n",
-      "                                                'gpi': array([2], dtype=int32),\n",
-      "                                                'lat': array([ 38.43003]),\n",
-      "                                                'lon': array([-120.9675]),\n",
-      "                                                'n_obs': array([482], dtype=int32),\n",
-      "                                                'p_R': array([ 0.], dtype=float32),\n",
-      "                                                'p_rho': array([ 0.], dtype=float32),\n",
-      "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.69356072], dtype=float32),\n",
-      "                                                'tau': array([ nan], dtype=float32)}}\n",
       "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-1.9682411], dtype=float32),\n",
-      "                                                'R': array([ 0.79960084], dtype=float32),\n",
-      "                                                'RMSD': array([ 13.06224251], dtype=float32),\n",
-      "                                                'gpi': array([3], dtype=int32),\n",
-      "                                                'lat': array([ 38.14956]),\n",
+      "                                                'R': array([0.79960084], dtype=float32),\n",
+      "                                                'RMSD': array([13.0622425], dtype=float32),\n",
+      "                                                'gpi': array([0], dtype=int32),\n",
+      "                                                'lat': array([38.14956]),\n",
       "                                                'lon': array([-120.78559]),\n",
       "                                                'n_obs': array([141], dtype=int32),\n",
-      "                                                'p_R': array([  1.38538225e-32], dtype=float32),\n",
-      "                                                'p_rho': array([  4.62621032e-39], dtype=float32),\n",
-      "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.84189808], dtype=float32),\n",
-      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "                                                'p_R': array([1.3853822e-32], dtype=float32),\n",
+      "                                                'p_rho': array([4.62621e-39], dtype=float32),\n",
+      "                                                'p_tau': array([nan], dtype=float32),\n",
+      "                                                'rho': array([0.8418981], dtype=float32),\n",
+      "                                                'tau': array([nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.6330102], dtype=float32),\n",
+      "                                                'R': array([0.7807141], dtype=float32),\n",
+      "                                                'RMSD': array([14.577002], dtype=float32),\n",
+      "                                                'gpi': array([1], dtype=int32),\n",
+      "                                                'lat': array([38.43003]),\n",
+      "                                                'lon': array([-120.9675]),\n",
+      "                                                'n_obs': array([482], dtype=int32),\n",
+      "                                                'p_R': array([0.], dtype=float32),\n",
+      "                                                'p_rho': array([0.], dtype=float32),\n",
+      "                                                'p_tau': array([nan], dtype=float32),\n",
+      "                                                'rho': array([0.6935607], dtype=float32),\n",
+      "                                                'tau': array([nan], dtype=float32)}}\n",
       "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.21823417], dtype=float32),\n",
-      "                                                'R': array([ 0.80635566], dtype=float32),\n",
-      "                                                'RMSD': array([ 12.90389824], dtype=float32),\n",
-      "                                                'gpi': array([4], dtype=int32),\n",
-      "                                                'lat': array([ 38.17353]),\n",
+      "                                                'R': array([0.80635566], dtype=float32),\n",
+      "                                                'RMSD': array([12.903898], dtype=float32),\n",
+      "                                                'gpi': array([2], dtype=int32),\n",
+      "                                                'lat': array([38.17353]),\n",
       "                                                'lon': array([-120.80639]),\n",
       "                                                'n_obs': array([251], dtype=int32),\n",
-      "                                                'p_R': array([ 0.], dtype=float32),\n",
-      "                                                'p_rho': array([  4.20389539e-45], dtype=float32),\n",
-      "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.74206454], dtype=float32),\n",
-      "                                                'tau': array([ nan], dtype=float32)}}\n",
-      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.14228749], dtype=float32),\n",
-      "                                                'R': array([ 0.50703788], dtype=float32),\n",
-      "                                                'RMSD': array([ 14.24668026], dtype=float32),\n",
-      "                                                'gpi': array([5], dtype=int32),\n",
-      "                                                'lat': array([ 34.25]),\n",
-      "                                                'lon': array([-105.417]),\n",
-      "                                                'n_obs': array([1927], dtype=int32),\n",
-      "                                                'p_R': array([ 0.], dtype=float32),\n",
-      "                                                'p_rho': array([  3.32948515e-42], dtype=float32),\n",
-      "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.30299741], dtype=float32),\n",
-      "                                                'tau': array([ nan], dtype=float32)}}\n",
-      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([ 0.2600247], dtype=float32),\n",
-      "                                                'R': array([ 0.53643185], dtype=float32),\n",
-      "                                                'RMSD': array([ 21.19682884], dtype=float32),\n",
-      "                                                'gpi': array([6], dtype=int32),\n",
-      "                                                'lat': array([ 37.133]),\n",
-      "                                                'lon': array([-97.083]),\n",
-      "                                                'n_obs': array([1887], dtype=int32),\n",
-      "                                                'p_R': array([ 0.], dtype=float32),\n",
-      "                                                'p_rho': array([ 0.], dtype=float32),\n",
-      "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.53143877], dtype=float32),\n",
-      "                                                'tau': array([ nan], dtype=float32)}}\n",
+      "                                                'p_R': array([0.], dtype=float32),\n",
+      "                                                'p_rho': array([4.e-45], dtype=float32),\n",
+      "                                                'p_tau': array([nan], dtype=float32),\n",
+      "                                                'rho': array([0.74206454], dtype=float32),\n",
+      "                                                'tau': array([nan], dtype=float32)}}\n",
       "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04437888], dtype=float32),\n",
-      "                                                'R': array([ 0.6058206], dtype=float32),\n",
-      "                                                'RMSD': array([ 17.3883934], dtype=float32),\n",
-      "                                                'gpi': array([7], dtype=int32),\n",
-      "                                                'lat': array([ 34.783]),\n",
+      "                                                'R': array([0.6058206], dtype=float32),\n",
+      "                                                'RMSD': array([17.388393], dtype=float32),\n",
+      "                                                'gpi': array([3], dtype=int32),\n",
+      "                                                'lat': array([34.783]),\n",
       "                                                'lon': array([-86.55]),\n",
       "                                                'n_obs': array([1652], dtype=int32),\n",
-      "                                                'p_R': array([ 0.], dtype=float32),\n",
-      "                                                'p_rho': array([ 0.], dtype=float32),\n",
-      "                                                'p_tau': array([ nan], dtype=float32),\n",
-      "                                                'rho': array([ 0.62204134], dtype=float32),\n",
-      "                                                'tau': array([ nan], dtype=float32)}}\n"
+      "                                                'p_R': array([0.], dtype=float32),\n",
+      "                                                'p_rho': array([0.], dtype=float32),\n",
+      "                                                'p_tau': array([nan], dtype=float32),\n",
+      "                                                'rho': array([0.62204134], dtype=float32),\n",
+      "                                                'tau': array([nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([0.2600247], dtype=float32),\n",
+      "                                                'R': array([0.53643185], dtype=float32),\n",
+      "                                                'RMSD': array([21.196829], dtype=float32),\n",
+      "                                                'gpi': array([4], dtype=int32),\n",
+      "                                                'lat': array([37.133]),\n",
+      "                                                'lon': array([-97.083]),\n",
+      "                                                'n_obs': array([1887], dtype=int32),\n",
+      "                                                'p_R': array([0.], dtype=float32),\n",
+      "                                                'p_rho': array([0.], dtype=float32),\n",
+      "                                                'p_tau': array([nan], dtype=float32),\n",
+      "                                                'rho': array([0.53143877], dtype=float32),\n",
+      "                                                'tau': array([nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.1422875], dtype=float32),\n",
+      "                                                'R': array([0.5070379], dtype=float32),\n",
+      "                                                'RMSD': array([14.24668], dtype=float32),\n",
+      "                                                'gpi': array([5], dtype=int32),\n",
+      "                                                'lat': array([34.25]),\n",
+      "                                                'lon': array([-105.417]),\n",
+      "                                                'n_obs': array([1927], dtype=int32),\n",
+      "                                                'p_R': array([0.], dtype=float32),\n",
+      "                                                'p_rho': array([3.33e-42], dtype=float32),\n",
+      "                                                'p_tau': array([nan], dtype=float32),\n",
+      "                                                'rho': array([0.3029974], dtype=float32),\n",
+      "                                                'tau': array([nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([0.237454], dtype=float32),\n",
+      "                                                'R': array([0.4996146], dtype=float32),\n",
+      "                                                'RMSD': array([11.583476], dtype=float32),\n",
+      "                                                'gpi': array([6], dtype=int32),\n",
+      "                                                'lat': array([33.8833]),\n",
+      "                                                'lon': array([102.1333]),\n",
+      "                                                'n_obs': array([357], dtype=int32),\n",
+      "                                                'p_R': array([6.127213e-24], dtype=float32),\n",
+      "                                                'p_rho': array([2.471651e-28], dtype=float32),\n",
+      "                                                'p_tau': array([nan], dtype=float32),\n",
+      "                                                'rho': array([0.53934574], dtype=float32),\n",
+      "                                                'tau': array([nan], dtype=float32)}}\n",
+      "{(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04330891], dtype=float32),\n",
+      "                                                'R': array([0.7128256], dtype=float32),\n",
+      "                                                'RMSD': array([7.729667], dtype=float32),\n",
+      "                                                'gpi': array([7], dtype=int32),\n",
+      "                                                'lat': array([33.6666]),\n",
+      "                                                'lon': array([102.1333]),\n",
+      "                                                'n_obs': array([384], dtype=int32),\n",
+      "                                                'p_R': array([0.], dtype=float32),\n",
+      "                                                'p_rho': array([0.], dtype=float32),\n",
+      "                                                'p_tau': array([nan], dtype=float32),\n",
+      "                                                'rho': array([0.7002289], dtype=float32),\n",
+      "                                                'tau': array([nan], dtype=float32)}}\n"
      ]
     }
    ],
    "source": [
+    "save_path = output_folder\n",
+    "\n",
     "import pprint\n",
     "for job in jobs:\n",
     "    \n",
     "    results = process.calc(*job)\n",
     "    pprint.pprint(results)\n",
-    "    netcdf_results_manager(results, save_path)\n"
+    "    netcdf_results_manager(results, save_path)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The validation is then performed by looping over all the defined jobs and storing the results. \n",
-    "You can see that the results are a dictionary where the key is a tuple defining the exact combination of datasets and columns that were used for the calculation of the metrics. The metrics itself are a dictionary of `metric-name: numpy.ndarray` which also include information about the gpi, lon and lat. Since all the information contained in the job is given to the metric calculator they can be stored in the results.\n",
+    "The validation is then performed by looping over all the defined jobs and storing the results.\n",
+    "You can see that the results are a dictionary where the key is a tuple defining the exact combination of datasets\n",
+    "and columns that were used for the calculation of the metrics. The metrics itself are a dictionary of `metric-name:\n",
+    " numpy.ndarray` which also include information about the gpi, lon and lat. Since all the information contained in\n",
+    "the job is given to the metric calculator they can be stored in the results.\n",
     "\n",
-    "Storing of the results to disk is at the moment supported by the `netcdf_results_manager` which creates a netCDF file for each dataset combination and stores each metric as a variable. We can inspect the stored netCDF file which is named after the dictionary key:"
+    "Storing of the results to disk is at the moment supported by the `netcdf_results_manager` which creates a netCDF\n",
+    "file for each dataset combination and stores each metric as a variable. We can inspect the stored netCDF file which\n",
+    " is named after the dictionary key:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 24,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "n_obs [ 384  357  482  141  251 1927 1887 1652]\n",
-      "tau [ nan  nan  nan  nan  nan  nan  nan  nan]\n",
-      "gpi [0 1 2 3 4 5 6 7]\n",
-      "RMSD [  7.72966719  11.58347607  14.57700157  13.06224251  12.90389824\n",
-      "  14.24668026  21.19682884  17.3883934 ]\n",
-      "lon [ 102.1333   102.1333  -120.9675  -120.78559 -120.80639 -105.417    -97.083\n",
-      "  -86.55   ]\n",
-      "p_tau [ nan  nan  nan  nan  nan  nan  nan  nan]\n",
-      "BIAS [-0.04330891  0.237454   -0.63301021 -1.9682411  -0.21823417 -0.14228749\n",
-      "  0.2600247  -0.04437888]\n",
-      "p_rho [  0.00000000e+00   2.47165110e-28   0.00000000e+00   4.62621032e-39\n",
-      "   4.20389539e-45   3.32948515e-42   0.00000000e+00   0.00000000e+00]\n",
-      "rho [ 0.70022893  0.53934574  0.69356072  0.84189808  0.74206454  0.30299741\n",
-      "  0.53143877  0.62204134]\n",
-      "lat [ 33.6666   33.8833   38.43003  38.14956  38.17353  34.25     37.133\n",
-      "  34.783  ]\n",
-      "R [ 0.7128256   0.4996146   0.78071409  0.79960084  0.80635566  0.50703788\n",
-      "  0.53643185  0.6058206 ]\n",
-      "p_R [  0.00000000e+00   6.12721281e-24   0.00000000e+00   1.38538225e-32\n",
-      "   0.00000000e+00   0.00000000e+00   0.00000000e+00   0.00000000e+00]\n"
+      "n_obs [141 482 251 1652 1887 1927 357 384 141 482 251 1652 1887 1927 357 384]\n",
+      "tau [nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan]\n",
+      "gpi [0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7]\n",
+      "RMSD [13.06224250793457 14.577001571655273 12.903898239135742 17.38839340209961\n",
+      " 21.196828842163086 14.24668025970459 11.583476066589355\n",
+      " 7.7296671867370605 13.06224250793457 14.577001571655273\n",
+      " 12.903898239135742 17.38839340209961 21.196828842163086 14.24668025970459\n",
+      " 11.583476066589355 7.7296671867370605]\n",
+      "lon [-120.78559 -120.9675 -120.80639 -86.55 -97.083 -105.417 102.1333 102.1333\n",
+      " -120.78559 -120.9675 -120.80639 -86.55 -97.083 -105.417 102.1333 102.1333]\n",
+      "p_tau [nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan]\n",
+      "BIAS [-1.9682410955429077 -0.63301020860672 -0.21823416650295258\n",
+      " -0.04437888041138649 0.26002469658851624 -0.1422874927520752\n",
+      " 0.23745399713516235 -0.043308909982442856 -1.9682410955429077\n",
+      " -0.63301020860672 -0.21823416650295258 -0.04437888041138649\n",
+      " 0.26002469658851624 -0.1422874927520752 0.23745399713516235\n",
+      " -0.043308909982442856]\n",
+      "p_rho [4.6262103163618786e-39 0.0 4.203895392974451e-45 0.0 0.0\n",
+      " 3.3294851512357654e-42 2.471651101555352e-28 0.0 4.6262103163618786e-39\n",
+      " 0.0 4.203895392974451e-45 0.0 0.0 3.3294851512357654e-42\n",
+      " 2.471651101555352e-28 0.0]\n",
+      "rho [0.8418980836868286 0.6935607194900513 0.7420645356178284\n",
+      " 0.6220413446426392 0.5314387679100037 0.3029974102973938\n",
+      " 0.5393457412719727 0.7002289295196533 0.8418980836868286\n",
+      " 0.6935607194900513 0.7420645356178284 0.6220413446426392\n",
+      " 0.5314387679100037 0.3029974102973938 0.5393457412719727\n",
+      " 0.7002289295196533]\n",
+      "lat [38.14956 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956\n",
+      " 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666]\n",
+      "R [0.7996008396148682 0.7807140946388245 0.8063556551933289\n",
+      " 0.6058205962181091 0.5364318490028381 0.507037878036499\n",
+      " 0.4996145963668823 0.71282559633255 0.7996008396148682 0.7807140946388245\n",
+      " 0.8063556551933289 0.6058205962181091 0.5364318490028381\n",
+      " 0.507037878036499 0.4996145963668823 0.71282559633255]\n",
+      "p_R [1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0 6.12721281290096e-24 0.0\n",
+      " 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0 6.12721281290096e-24 0.0]\n"
      ]
     }
    ],
@@ -552,10 +523,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 26,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def start_processing(job):\n",
@@ -569,18 +538,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`pytesmo.validation_framework.start_validation` can then be used to run your validation in parallel. \n",
-    "Your setup code can look like this Ipython notebook without the loop over the jobs. Otherwise the validation would be done twice. Save it into a `.py` file e.g. `my_validation.py`.\n",
+    "`pytesmo.validation_framework.start_validation` can then be used to run your validation in parallel.\n",
+    "Your setup code can look like this Ipython notebook without the loop over the jobs. Otherwise the validation would\n",
+    "be done twice. Save it into a `.py` file e.g. `my_validation.py`.\n",
     "\n",
-    "After [starting the ipyparallel cluster](http://ipyparallel.readthedocs.org/en/latest/process.html) you can then execute the following code:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
+    "After [starting the ipyparallel cluster](http://ipyparallel.readthedocs.org/en/latest/process.html) you can then\n",
+    "execute the following code:\n",
+    "\n",
     "```python\n",
     "from pytesmo.validation_framework import start_validation\n",
     "\n",
@@ -591,41 +555,39 @@
     "\n",
     "setup_code = \"my_validation.py\"\n",
     "start_validation(setup_code)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "```\n",
+    "\n",
     "## Masking datasets\n",
     "\n",
-    "Masking datasets are datasets that return a pandas DataFrame with boolean values. `True` means that the observation should be masked, `False` means it should be kept. All masking datasets are temporally matched in pairs to the temporal reference dataset. Only observations for which all masking datasets have a value of `False` are kept for further validation.\n",
+    "Masking datasets are datasets that return a pandas DataFrame with boolean values. `True` means that the observation\n",
+    " should be masked, `False` means it should be kept. All masking datasets are temporally matched in pairs to the\n",
+    "temporal reference dataset. Only observations for which all masking datasets have a value of `False` are kept for\n",
+    "further validation.\n",
     "\n",
-    "The masking datasets have the same format as the dataset dictionary and can be specified in the Validation class with the `masking_datasets` keyword.\n",
+    "The masking datasets have the same format as the dataset dictionary and can be specified in the Validation class\n",
+    "with the `masking_datasets` keyword.\n",
     "\n",
     "### Masking adapter\n",
     "\n",
-    "To easily transform an existing dataset into a masking dataset `pytesmo` offers a adapter class that calls the `read_ts` method of an existing dataset and performs the masking based on an operator and a given threshold."
+    "To easily transform an existing dataset into a masking dataset `pytesmo` offers a adapter class that calls the\n",
+    "`read_ts` method of an existing dataset and performs the masking based on an operator and a given threshold."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 27,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "date_time\n",
-      "2008-07-01 00:00:00    False\n",
-      "2008-07-01 01:00:00    False\n",
-      "2008-07-01 02:00:00    False\n",
-      "2008-07-01 03:00:00    False\n",
-      "2008-07-01 04:00:00    False\n",
+      "2012-12-14 19:00:00    False\n",
+      "2012-12-14 20:00:00    False\n",
+      "2012-12-14 21:00:00    False\n",
+      "2012-12-14 22:00:00    False\n",
+      "2012-12-14 23:00:00    False\n",
       "Name: soil moisture, dtype: bool\n"
      ]
     }
@@ -636,15 +598,6 @@
     "ds_mask = MaskingAdapter(ismn_reader, '<', 0.2)\n",
     "print ds_mask.read_ts(ids[0])['soil moisture'].head()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -663,9 +616,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/validation_framework.rst
+++ b/docs/validation_framework.rst
@@ -3,10 +3,10 @@ The pytesmo validation framework
 ================================
 
 The pytesmo validation framework takes care of iterating over datasets,
-spatial and temporal matching as well as sclaing. It uses metric
+spatial and temporal matching as well as scaling. It uses metric
 calculators to then calculate metrics that are returned to the user.
 There are several metrics calculators included in pytesmo but new ones
-can be added simply by writing a new class.
+can be added simply.
 
 Overview
 --------
@@ -65,12 +65,10 @@ Data space reference
 ~~~~~~~~~~~~~~~~~~~~
 
 It is often necessary to bring all the datasets into a common data space
-by using scaling. Pytesmo offers a choice of several scaling algorithms
-(e.g. CDF matching, min-max scaling, mean-std scaling, triple
-collocation based scaling). The data space reference can also be chosen
-independently from the other two references. New scaling methods can be
-implemented by writing a scaler class. An example of a scaler class can
-be found in the :py:class:`pytesmo.validation_framework.data_scalers.DefaultScaler`.
+by using. Scaling is often used for that and pytesmo offers a choice of
+several scaling algorithms (e.g. CDF matching, min-max scaling, mean-std
+scaling, triple collocation based scaling). The data space reference can
+also be chosen independently from the other two references.
 
 Data Flow
 ---------
@@ -79,23 +77,21 @@ After it is initialized, the validation framework works through the
 following steps:
 
 1. Read all the datasets for a certain job (gpi, lon, lat)
-2. Read all the masking datasets if any
+2. Read all the masking dataset if any
 3. Mask the temporal reference dataset using the masking data
 4. Temporally match all the chosen combinations of temporal reference
    and other datasets
-5. Scale all datasets into the data space of the data space reference,
-   if scaling is activated
-6. Turn the temporally matched time series over to the metric
+5. Turn the temporally matched time series over to the metric
    calculators
-7. Get the calculated metrics from the metric calculators
-8. Put all the metrics into a dictionary by dataset combination and
+6. Get the calculated metrics from the metric calculators
+7. Put all the metrics into a dictionary by dataset combination and
    return them.
 
 Masking datasets
 ----------------
 
-Masking datasets can be used if the the datasets that are compared do
-not contain the necessary information to mask them. For example we might
+Masking datasets can be used if the datasets that are compared do not
+contain the necessary information to mask them. For example we might
 want to use modelled soil temperature data to mask our soil moisture
 observations before comparing them. To be able to do that we just need a
 Dataset that returns a pandas.DataFrame with one column of boolean data
@@ -104,17 +100,15 @@ masked.
 
 Let's look at a first example.
 
-
 Example soil moisture validation: ASCAT - ISMN
 ----------------------------------------------
 
 This example shows how to setup the pytesmo validation framework to
 perform a comparison between ASCAT and ISMN data.
 
-.. code:: python
+.. code:: ipython2
 
     import os
-    import tempfile
     
     import pytesmo.validation_framework.metric_calculators as metrics_calculators
     
@@ -125,31 +119,48 @@ perform a comparison between ASCAT and ISMN data.
     from pytesmo.validation_framework.validation import Validation
     from pytesmo.validation_framework.results_manager import netcdf_results_manager
 
+You need the test data from https://github.com/TUW-GEO/pytesmo-test-data
+for this example
+
+.. code:: ipython2
+
+    testdata_folder = '/pytesmo/testdata'
+    output_folder = '/pytesmo/code/examples/output'
 
 First we initialize the data readers that we want to use. In this case
 the ASCAT soil moisture time series and in situ data from the ISMN.
 
 Initialize ASCAT reader
 
-.. code:: python
+.. code:: ipython2
 
-    ascat_data_folder = os.path.join('/home', 'cpa', 'workspace', 'pytesmo',
-                                     'tests', 'test-data', 'sat', 'ascat', 'netcdf', '55R22')
-    ascat_grid_folder = os.path.join('/media/sf_R', 'Datapool_processed', 'WARP',
-                                     'ancillary', 'warp5_grid')
-    static_layers_folder = os.path.join('/home', 'cpa', 'workspace', 'pytesmo',
-                                        'tests', 'test-data', 'sat',
-                                        'h_saf', 'static_layer')
-    
+    ascat_data_folder = os.path.join(testdata_folder,
+                                     'sat/ascat/netcdf/55R22')
+    ascat_grid_folder = os.path.join(testdata_folder,
+                                     'sat/ascat/netcdf/grid')
+    static_layers_folder = os.path.join(testdata_folder,
+                                        'sat/h_saf/static_layer')
     
     ascat_reader = AscatSsmCdr(ascat_data_folder, ascat_grid_folder,
+                               grid_filename='TUW_WARP5_grid_info_2_1.nc',
                                static_layer_path=static_layers_folder)
+    ascat_reader.read_bulk = True
+
+
+.. parsed-literal::
+
+    /space/tools/miniconda3/envs/pytesmo/lib/python2.7/site-packages/ascat/timeseries.py:128: UserWarning: WARNING: valid_range not used since it
+    cannot be safely cast to variable data type
+      land_gp = np.where(grid_nc.variables['land_flag'][:] == 1)[0]
+
 
 Initialize ISMN reader
 
-.. code:: python
+.. code:: ipython2
 
-    ismn_data_folder = '/data/Development/python/workspace/pytesmo/tests/test-data/ismn/multinetwork/header_values/'
+    ismn_data_folder = os.path.join(testdata_folder,
+                                     'ismn/multinetwork/header_values')
+    
     ismn_reader = ISMN_Interface(ismn_data_folder)
 
 The validation is run based on jobs. A job consists of at least three
@@ -162,7 +173,7 @@ dataset.
 **DO NOT CHANGE** the name ***jobs*** because it will be searched during
 the parallel processing!
 
-.. code:: python
+.. code:: ipython2
 
     jobs = []
     
@@ -170,12 +181,15 @@ the parallel processing!
     for idx in ids:
         metadata = ismn_reader.metadata[idx]
         jobs.append((idx, metadata['longitude'], metadata['latitude']))
-    print jobs
+    
+    print("Jobs (gpi, lon, lat):")
+    print(jobs)
 
 
 .. parsed-literal::
 
-    [(0, 102.13330000000001, 33.666600000000003), (1, 102.13330000000001, 33.883299999999998), (2, -120.9675, 38.430030000000002), (3, -120.78559, 38.149560000000001), (4, -120.80638999999999, 38.17353), (5, -105.417, 34.25), (6, -97.082999999999998, 37.133000000000003), (7, -86.549999999999997, 34.783000000000001)]
+    Jobs (gpi, lon, lat):
+    [(0, -120.78559, 38.14956), (1, -120.9675, 38.43003), (2, -120.80639, 38.17353), (3, -86.55, 34.783), (4, -97.083, 37.133), (5, -105.417, 34.25), (6, 102.1333, 33.8833), (7, 102.1333, 33.6666)]
 
 
 For this small test dataset it is only one job
@@ -184,21 +198,23 @@ It is important here that the ISMN reader has a read\_ts function that
 works by just using the ``dataset_id``. In this way the validation
 framework can go through the jobs and read the correct time series.
 
-.. code:: python
+.. code:: ipython2
 
     data = ismn_reader.read_ts(ids[0])
-    print data.head()
+    print('ISMN data example:')
+    print(data.head())
 
 
 .. parsed-literal::
 
-                         soil moisture soil moisture_flag soil moisture_orig_flag
-    date_time                                                                    
-    2008-07-01 00:00:00           0.45                  U                       M
-    2008-07-01 01:00:00           0.45                  U                       M
-    2008-07-01 02:00:00           0.45                  U                       M
-    2008-07-01 03:00:00           0.45                  U                       M
-    2008-07-01 04:00:00           0.45                  U                       M
+    ISMN data example:
+                         soil moisture soil moisture_flag  soil moisture_orig_flag
+    date_time                                                                     
+    2012-12-14 19:00:00         0.3166                  U                        0
+    2012-12-14 20:00:00         0.3259                  U                        0
+    2012-12-14 21:00:00         0.3259                  U                        0
+    2012-12-14 22:00:00         0.3263                  U                        0
+    2012-12-14 23:00:00         0.3263                  U                        0
 
 
 Initialize the Validation class
@@ -211,15 +227,20 @@ contains the settings about which metric calculators to use and how to
 perform the scaling into the reference data space. It is initialized in
 the following way:
 
-.. code:: python
+.. code:: ipython2
 
-    datasets = {'ISMN': {'class': ismn_reader, 
-                         'columns': ['soil moisture']},
-                'ASCAT': {'class': ascat_reader, 'columns': ['sm'],
-                          'kwargs': {'mask_frozen_prob': 80,
-                                     'mask_snow_prob': 80,
-                                     'mask_ssf': True}}
-               }
+    datasets = {
+        'ISMN': {
+            'class': ismn_reader,
+            'columns': ['soil moisture']
+        },
+        'ASCAT': {
+            'class': ascat_reader,
+            'columns': ['sm'],
+            'kwargs': {'mask_frozen_prob': 80,
+                       'mask_snow_prob': 80,
+                       'mask_ssf': True}
+        }}
 
 The datasets dictionary contains all the information about the datasets
 to read. The ``class`` is the dataset class to use which we have already
@@ -234,24 +255,24 @@ included frozen and snow probabilities as well as the SSF. There are
 also other keys that can be used here. Please see the documentation for
 explanations.
 
-.. code:: python
+.. code:: ipython2
 
     period = [datetime(2007, 1, 1), datetime(2014, 12, 31)]
     basic_metrics = metrics_calculators.BasicMetrics(other_name='k1')
     
     process = Validation(
-        datasets, 'ISMN', {(2, 2): basic_metrics.calc_metrics},
+        datasets, 'ISMN',
         temporal_ref='ASCAT',
         scaling='lin_cdf_match',
         scaling_ref='ASCAT',   
+        metrics_calculators={(2, 2): basic_metrics.calc_metrics},
         period=period)
-
 
 During the initialization of the Validation class we can also tell it
 other things that it needs to know. In this case it uses the datasets we
 have specified earlier. The spatial reference is the ``'ISMN'`` dataset
-which is the second argument. The third argument looks a little bit
-strange so let's look at it in more detail.
+which is the second argument. The 'metrics\_calculators' argument looks
+a little bit strange so let's look at it in more detail.
 
 It is a dictionary with a tuple as the key and a function as the value.
 The key tuple ``(n, k)`` has the following meaning: ``n`` datasets are
@@ -277,12 +298,10 @@ path where the results will be saved. **DO NOT CHANGE** the name
 ***save\_path*** because it will be searched during the parallel
 processing!
 
-.. code:: python
+.. code:: ipython2
 
-    save_path = tempfile.mkdtemp()
-
-.. code:: python
-
+    save_path = output_folder
+    
     import pprint
     for job in jobs:
         
@@ -291,112 +310,119 @@ processing!
         netcdf_results_manager(results, save_path)
 
 
+.. parsed-literal::
+
+    /space/tools/miniconda3/envs/pytesmo/lib/python2.7/site-packages/pandas/core/reshape/merge.py:558: UserWarning: merging between different levels can give an unintended result (1 levels on the left, 2 on the right)
+      warnings.warn(msg, UserWarning)
+    /space/tools/miniconda3/envs/pytesmo/lib/python2.7/site-packages/pandas/core/reshape/merge.py:558: UserWarning: merging between different levels can give an unintended result (2 levels on the left, 1 on the right)
+      warnings.warn(msg, UserWarning)
+
 
 .. parsed-literal::
 
-    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04330891], dtype=float32),
-                                                    'R': array([ 0.7128256], dtype=float32),
-                                                    'RMSD': array([ 7.72966719], dtype=float32),
-                                                    'gpi': array([0], dtype=int32),
-                                                    'lat': array([ 33.6666]),
-                                                    'lon': array([ 102.1333]),
-                                                    'n_obs': array([384], dtype=int32),
-                                                    'p_R': array([ 0.], dtype=float32),
-                                                    'p_rho': array([ 0.], dtype=float32),
-                                                    'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.70022893], dtype=float32),
-                                                    'tau': array([ nan], dtype=float32)}}
-    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([ 0.237454], dtype=float32),
-                                                    'R': array([ 0.4996146], dtype=float32),
-                                                    'RMSD': array([ 11.58347607], dtype=float32),
-                                                    'gpi': array([1], dtype=int32),
-                                                    'lat': array([ 33.8833]),
-                                                    'lon': array([ 102.1333]),
-                                                    'n_obs': array([357], dtype=int32),
-                                                    'p_R': array([  6.12721281e-24], dtype=float32),
-                                                    'p_rho': array([  2.47165110e-28], dtype=float32),
-                                                    'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.53934574], dtype=float32),
-                                                    'tau': array([ nan], dtype=float32)}}
-    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.63301021], dtype=float32),
-                                                    'R': array([ 0.78071409], dtype=float32),
-                                                    'RMSD': array([ 14.57700157], dtype=float32),
-                                                    'gpi': array([2], dtype=int32),
-                                                    'lat': array([ 38.43003]),
-                                                    'lon': array([-120.9675]),
-                                                    'n_obs': array([482], dtype=int32),
-                                                    'p_R': array([ 0.], dtype=float32),
-                                                    'p_rho': array([ 0.], dtype=float32),
-                                                    'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.69356072], dtype=float32),
-                                                    'tau': array([ nan], dtype=float32)}}
     {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-1.9682411], dtype=float32),
-                                                    'R': array([ 0.79960084], dtype=float32),
-                                                    'RMSD': array([ 13.06224251], dtype=float32),
-                                                    'gpi': array([3], dtype=int32),
-                                                    'lat': array([ 38.14956]),
+                                                    'R': array([0.79960084], dtype=float32),
+                                                    'RMSD': array([13.0622425], dtype=float32),
+                                                    'gpi': array([0], dtype=int32),
+                                                    'lat': array([38.14956]),
                                                     'lon': array([-120.78559]),
                                                     'n_obs': array([141], dtype=int32),
-                                                    'p_R': array([  1.38538225e-32], dtype=float32),
-                                                    'p_rho': array([  4.62621032e-39], dtype=float32),
-                                                    'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.84189808], dtype=float32),
-                                                    'tau': array([ nan], dtype=float32)}}
+                                                    'p_R': array([1.3853822e-32], dtype=float32),
+                                                    'p_rho': array([4.62621e-39], dtype=float32),
+                                                    'p_tau': array([nan], dtype=float32),
+                                                    'rho': array([0.8418981], dtype=float32),
+                                                    'tau': array([nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.6330102], dtype=float32),
+                                                    'R': array([0.7807141], dtype=float32),
+                                                    'RMSD': array([14.577002], dtype=float32),
+                                                    'gpi': array([1], dtype=int32),
+                                                    'lat': array([38.43003]),
+                                                    'lon': array([-120.9675]),
+                                                    'n_obs': array([482], dtype=int32),
+                                                    'p_R': array([0.], dtype=float32),
+                                                    'p_rho': array([0.], dtype=float32),
+                                                    'p_tau': array([nan], dtype=float32),
+                                                    'rho': array([0.6935607], dtype=float32),
+                                                    'tau': array([nan], dtype=float32)}}
     {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.21823417], dtype=float32),
-                                                    'R': array([ 0.80635566], dtype=float32),
-                                                    'RMSD': array([ 12.90389824], dtype=float32),
-                                                    'gpi': array([4], dtype=int32),
-                                                    'lat': array([ 38.17353]),
+                                                    'R': array([0.80635566], dtype=float32),
+                                                    'RMSD': array([12.903898], dtype=float32),
+                                                    'gpi': array([2], dtype=int32),
+                                                    'lat': array([38.17353]),
                                                     'lon': array([-120.80639]),
                                                     'n_obs': array([251], dtype=int32),
-                                                    'p_R': array([ 0.], dtype=float32),
-                                                    'p_rho': array([  4.20389539e-45], dtype=float32),
-                                                    'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.74206454], dtype=float32),
-                                                    'tau': array([ nan], dtype=float32)}}
-    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.14228749], dtype=float32),
-                                                    'R': array([ 0.50703788], dtype=float32),
-                                                    'RMSD': array([ 14.24668026], dtype=float32),
-                                                    'gpi': array([5], dtype=int32),
-                                                    'lat': array([ 34.25]),
-                                                    'lon': array([-105.417]),
-                                                    'n_obs': array([1927], dtype=int32),
-                                                    'p_R': array([ 0.], dtype=float32),
-                                                    'p_rho': array([  3.32948515e-42], dtype=float32),
-                                                    'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.30299741], dtype=float32),
-                                                    'tau': array([ nan], dtype=float32)}}
-    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([ 0.2600247], dtype=float32),
-                                                    'R': array([ 0.53643185], dtype=float32),
-                                                    'RMSD': array([ 21.19682884], dtype=float32),
-                                                    'gpi': array([6], dtype=int32),
-                                                    'lat': array([ 37.133]),
-                                                    'lon': array([-97.083]),
-                                                    'n_obs': array([1887], dtype=int32),
-                                                    'p_R': array([ 0.], dtype=float32),
-                                                    'p_rho': array([ 0.], dtype=float32),
-                                                    'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.53143877], dtype=float32),
-                                                    'tau': array([ nan], dtype=float32)}}
+                                                    'p_R': array([0.], dtype=float32),
+                                                    'p_rho': array([4.e-45], dtype=float32),
+                                                    'p_tau': array([nan], dtype=float32),
+                                                    'rho': array([0.74206454], dtype=float32),
+                                                    'tau': array([nan], dtype=float32)}}
     {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04437888], dtype=float32),
-                                                    'R': array([ 0.6058206], dtype=float32),
-                                                    'RMSD': array([ 17.3883934], dtype=float32),
-                                                    'gpi': array([7], dtype=int32),
-                                                    'lat': array([ 34.783]),
+                                                    'R': array([0.6058206], dtype=float32),
+                                                    'RMSD': array([17.388393], dtype=float32),
+                                                    'gpi': array([3], dtype=int32),
+                                                    'lat': array([34.783]),
                                                     'lon': array([-86.55]),
                                                     'n_obs': array([1652], dtype=int32),
-                                                    'p_R': array([ 0.], dtype=float32),
-                                                    'p_rho': array([ 0.], dtype=float32),
-                                                    'p_tau': array([ nan], dtype=float32),
-                                                    'rho': array([ 0.62204134], dtype=float32),
-                                                    'tau': array([ nan], dtype=float32)}}
+                                                    'p_R': array([0.], dtype=float32),
+                                                    'p_rho': array([0.], dtype=float32),
+                                                    'p_tau': array([nan], dtype=float32),
+                                                    'rho': array([0.62204134], dtype=float32),
+                                                    'tau': array([nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([0.2600247], dtype=float32),
+                                                    'R': array([0.53643185], dtype=float32),
+                                                    'RMSD': array([21.196829], dtype=float32),
+                                                    'gpi': array([4], dtype=int32),
+                                                    'lat': array([37.133]),
+                                                    'lon': array([-97.083]),
+                                                    'n_obs': array([1887], dtype=int32),
+                                                    'p_R': array([0.], dtype=float32),
+                                                    'p_rho': array([0.], dtype=float32),
+                                                    'p_tau': array([nan], dtype=float32),
+                                                    'rho': array([0.53143877], dtype=float32),
+                                                    'tau': array([nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.1422875], dtype=float32),
+                                                    'R': array([0.5070379], dtype=float32),
+                                                    'RMSD': array([14.24668], dtype=float32),
+                                                    'gpi': array([5], dtype=int32),
+                                                    'lat': array([34.25]),
+                                                    'lon': array([-105.417]),
+                                                    'n_obs': array([1927], dtype=int32),
+                                                    'p_R': array([0.], dtype=float32),
+                                                    'p_rho': array([3.33e-42], dtype=float32),
+                                                    'p_tau': array([nan], dtype=float32),
+                                                    'rho': array([0.3029974], dtype=float32),
+                                                    'tau': array([nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([0.237454], dtype=float32),
+                                                    'R': array([0.4996146], dtype=float32),
+                                                    'RMSD': array([11.583476], dtype=float32),
+                                                    'gpi': array([6], dtype=int32),
+                                                    'lat': array([33.8833]),
+                                                    'lon': array([102.1333]),
+                                                    'n_obs': array([357], dtype=int32),
+                                                    'p_R': array([6.127213e-24], dtype=float32),
+                                                    'p_rho': array([2.471651e-28], dtype=float32),
+                                                    'p_tau': array([nan], dtype=float32),
+                                                    'rho': array([0.53934574], dtype=float32),
+                                                    'tau': array([nan], dtype=float32)}}
+    {(('ASCAT', 'sm'), ('ISMN', 'soil moisture')): {'BIAS': array([-0.04330891], dtype=float32),
+                                                    'R': array([0.7128256], dtype=float32),
+                                                    'RMSD': array([7.729667], dtype=float32),
+                                                    'gpi': array([7], dtype=int32),
+                                                    'lat': array([33.6666]),
+                                                    'lon': array([102.1333]),
+                                                    'n_obs': array([384], dtype=int32),
+                                                    'p_R': array([0.], dtype=float32),
+                                                    'p_rho': array([0.], dtype=float32),
+                                                    'p_tau': array([nan], dtype=float32),
+                                                    'rho': array([0.7002289], dtype=float32),
+                                                    'tau': array([nan], dtype=float32)}}
 
 
 The validation is then performed by looping over all the defined jobs
 and storing the results. You can see that the results are a dictionary
 where the key is a tuple defining the exact combination of datasets and
 columns that were used for the calculation of the metrics. The metrics
-itself are a dictionary of ``metric-name: numpy.ndarray`` which also
+itself are a dictionary of ``metric-name:  numpy.ndarray`` which also
 include information about the gpi, lon and lat. Since all the
 information contained in the job is given to the metric calculator they
 can be stored in the results.
@@ -406,7 +432,7 @@ Storing of the results to disk is at the moment supported by the
 combination and stores each metric as a variable. We can inspect the
 stored netCDF file which is named after the dictionary key:
 
-.. code:: python
+.. code:: ipython2
 
     import netCDF4
     results_fname = os.path.join(save_path, 'ASCAT.sm_with_ISMN.soil moisture.nc')
@@ -418,26 +444,98 @@ stored netCDF file which is named after the dictionary key:
 
 .. parsed-literal::
 
-    n_obs [ 384  357  482  141  251 1927 1887 1652]
-    tau [ nan  nan  nan  nan  nan  nan  nan  nan]
-    gpi [0 1 2 3 4 5 6 7]
-    RMSD [  7.72966719  11.58347607  14.57700157  13.06224251  12.90389824
-      14.24668026  21.19682884  17.3883934 ]
-    lon [ 102.1333   102.1333  -120.9675  -120.78559 -120.80639 -105.417    -97.083
-      -86.55   ]
-    p_tau [ nan  nan  nan  nan  nan  nan  nan  nan]
-    BIAS [-0.04330891  0.237454   -0.63301021 -1.9682411  -0.21823417 -0.14228749
-      0.2600247  -0.04437888]
-    p_rho [  0.00000000e+00   2.47165110e-28   0.00000000e+00   4.62621032e-39
-       4.20389539e-45   3.32948515e-42   0.00000000e+00   0.00000000e+00]
-    rho [ 0.70022893  0.53934574  0.69356072  0.84189808  0.74206454  0.30299741
-      0.53143877  0.62204134]
-    lat [ 33.6666   33.8833   38.43003  38.14956  38.17353  34.25     37.133
-      34.783  ]
-    R [ 0.7128256   0.4996146   0.78071409  0.79960084  0.80635566  0.50703788
-      0.53643185  0.6058206 ]
-    p_R [  0.00000000e+00   6.12721281e-24   0.00000000e+00   1.38538225e-32
-       0.00000000e+00   0.00000000e+00   0.00000000e+00   0.00000000e+00]
+    n_obs [141 482 251 1652 1887 1927 357 384 141 482 251 1652 1887 1927 357 384 141
+     482 141 482 251 1652 1887 1927 357 384 141 482 251 1652 1887 1927 357 384
+     141 482 251 1652 1887 1927 357 384]
+    tau [nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan
+     nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan
+     nan nan nan nan nan nan]
+    gpi [0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2
+     3 4 5 6 7]
+    RMSD [13.06224250793457 14.577001571655273 12.903898239135742 17.38839340209961
+     21.196828842163086 14.24668025970459 11.583476066589355
+     7.7296671867370605 13.06224250793457 14.577001571655273
+     12.903898239135742 17.38839340209961 21.196828842163086 14.24668025970459
+     11.583476066589355 7.7296671867370605 13.06224250793457
+     14.577001571655273 13.06224250793457 14.577001571655273
+     12.903898239135742 17.38839340209961 21.196828842163086 14.24668025970459
+     11.583476066589355 7.7296671867370605 13.06224250793457
+     14.577001571655273 12.903898239135742 17.38839340209961
+     21.196828842163086 14.24668025970459 11.583476066589355
+     7.7296671867370605 13.06224250793457 14.577001571655273
+     12.903898239135742 17.38839340209961 21.196828842163086 14.24668025970459
+     11.583476066589355 7.7296671867370605]
+    lon [-120.78559 -120.9675 -120.80639 -86.55 -97.083 -105.417 102.1333 102.1333
+     -120.78559 -120.9675 -120.80639 -86.55 -97.083 -105.417 102.1333 102.1333
+     -120.78559 -120.9675 -120.78559 -120.9675 -120.80639 -86.55 -97.083
+     -105.417 102.1333 102.1333 -120.78559 -120.9675 -120.80639 -86.55 -97.083
+     -105.417 102.1333 102.1333 -120.78559 -120.9675 -120.80639 -86.55 -97.083
+     -105.417 102.1333 102.1333]
+    p_tau [nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan
+     nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan nan
+     nan nan nan nan nan nan]
+    BIAS [-1.9682410955429077 -0.63301020860672 -0.21823416650295258
+     -0.04437888041138649 0.26002469658851624 -0.1422874927520752
+     0.23745399713516235 -0.043308909982442856 -1.9682410955429077
+     -0.63301020860672 -0.21823416650295258 -0.04437888041138649
+     0.26002469658851624 -0.1422874927520752 0.23745399713516235
+     -0.043308909982442856 -1.9682410955429077 -0.63301020860672
+     -1.9682410955429077 -0.63301020860672 -0.21823416650295258
+     -0.04437888041138649 0.26002469658851624 -0.1422874927520752
+     0.23745399713516235 -0.043308909982442856 -1.9682410955429077
+     -0.63301020860672 -0.21823416650295258 -0.04437888041138649
+     0.26002469658851624 -0.1422874927520752 0.23745399713516235
+     -0.043308909982442856 -1.9682410955429077 -0.63301020860672
+     -0.21823416650295258 -0.04437888041138649 0.26002469658851624
+     -0.1422874927520752 0.23745399713516235 -0.043308909982442856]
+    p_rho [4.6262103163618786e-39 0.0 4.203895392974451e-45 0.0 0.0
+     3.3294851512357654e-42 2.471651101555352e-28 0.0 4.6262103163618786e-39
+     0.0 4.203895392974451e-45 0.0 0.0 3.3294851512357654e-42
+     2.471651101555352e-28 0.0 4.6262103163618786e-39 0.0
+     4.6262103163618786e-39 0.0 4.203895392974451e-45 0.0 0.0
+     3.3294851512357654e-42 2.471651101555352e-28 0.0 4.6262103163618786e-39
+     0.0 4.203895392974451e-45 0.0 0.0 3.3294851512357654e-42
+     2.471651101555352e-28 0.0 4.6262103163618786e-39 0.0
+     4.203895392974451e-45 0.0 0.0 3.3294851512357654e-42
+     2.471651101555352e-28 0.0]
+    rho [0.8418980836868286 0.6935607194900513 0.7420645356178284
+     0.6220413446426392 0.5314387679100037 0.3029974102973938
+     0.5393457412719727 0.7002289295196533 0.8418980836868286
+     0.6935607194900513 0.7420645356178284 0.6220413446426392
+     0.5314387679100037 0.3029974102973938 0.5393457412719727
+     0.7002289295196533 0.8418980836868286 0.6935607194900513
+     0.8418980836868286 0.6935607194900513 0.7420645356178284
+     0.6220413446426392 0.5314387679100037 0.3029974102973938
+     0.5393457412719727 0.7002289295196533 0.8418980836868286
+     0.6935607194900513 0.7420645356178284 0.6220413446426392
+     0.5314387679100037 0.3029974102973938 0.5393457412719727
+     0.7002289295196533 0.8418980836868286 0.6935607194900513
+     0.7420645356178284 0.6220413446426392 0.5314387679100037
+     0.3029974102973938 0.5393457412719727 0.7002289295196533]
+    lat [38.14956 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956
+     38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956 38.43003
+     38.14956 38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956
+     38.43003 38.17353 34.783 37.133 34.25 33.8833 33.6666 38.14956 38.43003
+     38.17353 34.783 37.133 34.25 33.8833 33.6666]
+    R [0.7996008396148682 0.7807140946388245 0.8063556551933289
+     0.6058205962181091 0.5364318490028381 0.507037878036499
+     0.4996145963668823 0.71282559633255 0.7996008396148682 0.7807140946388245
+     0.8063556551933289 0.6058205962181091 0.5364318490028381
+     0.507037878036499 0.4996145963668823 0.71282559633255 0.7996008396148682
+     0.7807140946388245 0.7996008396148682 0.7807140946388245
+     0.8063556551933289 0.6058205962181091 0.5364318490028381
+     0.507037878036499 0.4996145963668823 0.71282559633255 0.7996008396148682
+     0.7807140946388245 0.8063556551933289 0.6058205962181091
+     0.5364318490028381 0.507037878036499 0.4996145963668823 0.71282559633255
+     0.7996008396148682 0.7807140946388245 0.8063556551933289
+     0.6058205962181091 0.5364318490028381 0.507037878036499
+     0.4996145963668823 0.71282559633255]
+    p_R [1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0 6.12721281290096e-24 0.0
+     1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0 6.12721281290096e-24 0.0
+     1.3853822467078656e-32 0.0 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0
+     6.12721281290096e-24 0.0 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0
+     6.12721281290096e-24 0.0 1.3853822467078656e-32 0.0 0.0 0.0 0.0 0.0
+     6.12721281290096e-24 0.0]
 
 
 Parallel processing
@@ -446,7 +544,7 @@ Parallel processing
 The same code can be executed in parallel by defining the following
 ``start_processing`` function.
 
-.. code:: python
+.. code:: ipython2
 
     def start_processing(job):
         try:
@@ -495,25 +593,55 @@ Masking adapter
 
 To easily transform an existing dataset into a masking dataset
 ``pytesmo`` offers a adapter class that calls the ``read_ts`` method of
-an existing dataset and performs the masking based on an operator and a
-given threshold.
+an existing dataset and creates a masking dataset based on an operator,
+a given threshold, and (optionally) a column name.
 
-.. code:: python
+.. code:: ipython2
 
     from pytesmo.validation_framework.adapters import MaskingAdapter
     
-    ds_mask = MaskingAdapter(ismn_reader, '<', 0.2)
-    print ds_mask.read_ts(ids[0])['soil moisture'].head()
+    ds_mask = MaskingAdapter(ismn_reader, '<', 0.2, 'soil moisture')
+    print ds_mask.read_ts(ids[0]).head()
 
 
 .. parsed-literal::
 
-    date_time
-    2008-07-01 00:00:00    False
-    2008-07-01 01:00:00    False
-    2008-07-01 02:00:00    False
-    2008-07-01 03:00:00    False
-    2008-07-01 04:00:00    False
-    Name: soil moisture, dtype: bool
+                         soil moisture
+    date_time                         
+    2012-12-14 19:00:00          False
+    2012-12-14 20:00:00          False
+    2012-12-14 21:00:00          False
+    2012-12-14 22:00:00          False
+    2012-12-14 23:00:00          False
 
+
+Self-masking adapter
+~~~~~~~~~~~~~~~~~~~~
+
+``pytesmo`` also has a class that masks a dataset "on-the-fly", based on
+one of the columns it contains and an operator and a threshold. In
+contrast to the masking adapter mentioned above, the output of the
+self-masking adapter is the masked data, not the the mask. The
+self-masking adapter wraps a data reader, which must have a ``read_ts``
+or ``read`` method. Calling its ``read_ts``/``read`` method will return
+the masked data - more precisely a DataFrame with only rows where the
+masking condition is true.
+
+.. code:: ipython2
+
+    from pytesmo.validation_framework.adapters import SelfMaskingAdapter
+    
+    ds_mask = SelfMaskingAdapter(ismn_reader, '<', 0.2, 'soil moisture')
+    print ds_mask.read_ts(ids[0]).head()
+
+
+.. parsed-literal::
+
+                         soil moisture soil moisture_flag  soil moisture_orig_flag
+    date_time                                                                     
+    2013-08-21 22:00:00         0.1682                  U                        0
+    2013-08-21 23:00:00         0.1665                  U                        0
+    2013-08-22 00:00:00         0.1682                  U                        0
+    2013-08-22 01:00:00         0.1615                  U                        0
+    2013-08-22 02:00:00         0.1631                  U                        0
 

--- a/pytesmo/validation_framework/adapters.py
+++ b/pytesmo/validation_framework/adapters.py
@@ -54,23 +54,30 @@ class MaskingAdapter(object):
 
     """
 
-    def __init__(self, cls, op, threshold):
+    def __init__(self, cls, op, threshold, column_name = None):
         self.cls = cls
 
         self.op_lookup = {'<': operator.lt,
                           '<=': operator.le,
                           '==': operator.eq,
+                          '!=': operator.ne,
                           '>=': operator.ge,
                           '>': operator.gt}
         self.operator = self.op_lookup[op]
         self.threshold = threshold
 
+        self.column_name = column_name
+
     def read_ts(self, *args, **kwargs):
         data = self.cls.read_ts(*args, **kwargs)
+        if self.column_name is not None:
+            data = data.loc[:, [self.column_name]]
         return self.operator(data, self.threshold)
 
     def read(self, *args, **kwargs):
         data = self.cls.read(*args, **kwargs)
+        if self.column_name is not None:
+            data = data.loc[:, [self.column_name]]
         return self.operator(data, self.threshold)
 
 

--- a/pytesmo/validation_framework/adapters.py
+++ b/pytesmo/validation_framework/adapters.py
@@ -117,8 +117,7 @@ class SelfMaskingAdapter(object):
 
     def __mask(self, data):
         mask = self.operator(data[self.column_name], self.threshold)
-        data = data[mask]
-        return data
+        return data[mask]
 
     def read_ts(self, *args, **kwargs):
         data = self.cls.read_ts(*args, **kwargs)

--- a/pytesmo/validation_framework/adapters.py
+++ b/pytesmo/validation_framework/adapters.py
@@ -116,7 +116,6 @@ class SelfMaskingAdapter(object):
         self.column_name = column_name
 
     def __mask(self, data):
-#         data = data[data['frozen_prob'] < mask_frozen_prob]
         mask = self.operator(data[self.column_name], self.threshold)
         data = data[mask]
         return data

--- a/pytesmo/validation_framework/adapters.py
+++ b/pytesmo/validation_framework/adapters.py
@@ -98,7 +98,7 @@ class SelfMaskingAdapter(object):
     threshold:
         value to use as the threshold combined with the operator
     column_name: string
-        name of the column to cut the read masking dataset to
+        name of the column to apply the threshold to
     """
 
     def __init__(self, cls, op, threshold, column_name):

--- a/tests/test_validation_framwork/test_adapters.py
+++ b/tests/test_validation_framwork/test_adapters.py
@@ -40,23 +40,34 @@ import numpy.testing as nptest
 
 
 def test_masking_adapter():
-    ds = TestDataset('', n=20)
-    ds_mask = MaskingAdapter(ds, '<', 10)
-    data_masked = ds_mask.read_ts()
-    nptest.assert_almost_equal(data_masked['x'].values,
-                               np.concatenate([np.ones((10), dtype=bool),
-                                               np.zeros((10), dtype=bool)]))
+    for col in (None, 'y'):
+        ds = TestDataset('', n=20)
+        ds_mask = MaskingAdapter(ds, '<', 10, col)
+        data_masked = ds_mask.read_ts()
+        data_masked2 = ds_mask.read()
 
-    nptest.assert_almost_equal(
-        data_masked['y'].values, np.ones((20), dtype=bool))
+        if col is None:
+            nptest.assert_almost_equal(data_masked['x'].values,
+                                       np.concatenate([np.ones((10), dtype=bool),
+                                                       np.zeros((10), dtype=bool)]))
+            nptest.assert_almost_equal(data_masked2['x'].values,
+                                       np.concatenate([np.ones((10), dtype=bool),
+                                                       np.zeros((10), dtype=bool)]))
 
+        nptest.assert_almost_equal(
+            data_masked['y'].values, np.ones((20), dtype=bool))
+        nptest.assert_almost_equal(
+            data_masked2['y'].values, np.ones((20), dtype=bool))
 
 def test_anomaly_adapter():
     ds = TestDataset('', n=20)
     ds_anom = AnomalyAdapter(ds)
     data_anom = ds_anom.read_ts()
+    data_anom2 = ds_anom.read()
     nptest.assert_almost_equal(data_anom['x'].values[0], -8.5)
     nptest.assert_almost_equal(data_anom['y'].values[0], -4.25)
+    nptest.assert_almost_equal(data_anom2['x'].values[0], -8.5)
+    nptest.assert_almost_equal(data_anom2['y'].values[0], -4.25)
 
 
 def test_anomaly_adapter_one_column():
@@ -71,8 +82,11 @@ def test_anomaly_clim_adapter():
     ds = TestDataset('', n=20)
     ds_anom = AnomalyClimAdapter(ds)
     data_anom = ds_anom.read_ts()
+    data_anom2 = ds_anom.read()
     nptest.assert_almost_equal(data_anom['x'].values[4], -5.5)
     nptest.assert_almost_equal(data_anom['y'].values[4], -2.75)
+    nptest.assert_almost_equal(data_anom2['x'].values[4], -5.5)
+    nptest.assert_almost_equal(data_anom2['y'].values[4], -2.75)
 
 
 def test_anomaly_clim_adapter_one_column():

--- a/tests/test_validation_framwork/test_adapters.py
+++ b/tests/test_validation_framwork/test_adapters.py
@@ -31,6 +31,7 @@ Test for the adapters.
 '''
 
 from pytesmo.validation_framework.adapters import MaskingAdapter
+from pytesmo.validation_framework.adapters import SelfMaskingAdapter
 from pytesmo.validation_framework.adapters import AnomalyAdapter
 from pytesmo.validation_framework.adapters import AnomalyClimAdapter
 from test_datasets import TestDataset
@@ -40,24 +41,38 @@ import numpy.testing as nptest
 
 
 def test_masking_adapter():
-    for col in (None, 'y'):
+    for col in (None, 'x'):
         ds = TestDataset('', n=20)
         ds_mask = MaskingAdapter(ds, '<', 10, col)
         data_masked = ds_mask.read_ts()
         data_masked2 = ds_mask.read()
 
-        if col is None:
-            nptest.assert_almost_equal(data_masked['x'].values,
-                                       np.concatenate([np.ones((10), dtype=bool),
-                                                       np.zeros((10), dtype=bool)]))
-            nptest.assert_almost_equal(data_masked2['x'].values,
-                                       np.concatenate([np.ones((10), dtype=bool),
-                                                       np.zeros((10), dtype=bool)]))
+        nptest.assert_almost_equal(data_masked['x'].values,
+                                   np.concatenate([np.ones((10), dtype=bool),
+                                                   np.zeros((10), dtype=bool)]))
+        nptest.assert_almost_equal(data_masked2['x'].values,
+                                   np.concatenate([np.ones((10), dtype=bool),
+                                                   np.zeros((10), dtype=bool)]))
 
-        nptest.assert_almost_equal(
-            data_masked['y'].values, np.ones((20), dtype=bool))
-        nptest.assert_almost_equal(
-            data_masked2['y'].values, np.ones((20), dtype=bool))
+        if col is None:
+            nptest.assert_almost_equal(
+                data_masked['y'].values, np.ones((20), dtype=bool))
+            nptest.assert_almost_equal(
+                data_masked2['y'].values, np.ones((20), dtype=bool))
+
+def test_self_masking_adapter():
+    ref_x = np.arange(10)
+    ref_y = np.arange(10) * 0.5
+    ds = TestDataset('', n=20)
+    
+    ds_mask = SelfMaskingAdapter(ds, '<', 10, 'x')
+    data_masked = ds_mask.read_ts()
+    data_masked2 = ds_mask.read()
+
+    nptest.assert_almost_equal(data_masked['x'].values,ref_x)
+    nptest.assert_almost_equal(data_masked2['x'].values,ref_x)
+    nptest.assert_almost_equal(data_masked['y'].values,ref_y)
+    nptest.assert_almost_equal(data_masked2['y'].values,ref_y)
 
 def test_anomaly_adapter():
     ds = TestDataset('', n=20)


### PR DESCRIPTION
Extends the existing MaskingAdapter so that it can be used reduce multi-column masking datasets to one column and do "not equal" comparisons. Adds a SelfMaskingAdapter that wraps a data reader and allows to mask the data while reading, based on a comparison operation on one column (column, operation, and threshold can be specified).