### PR TITLE
Try fixing failing issues with new pandas version (0.23)

### DIFF
--- a/pytesmo/validation_framework/temporal_matchers.py
+++ b/pytesmo/validation_framework/temporal_matchers.py
@@ -35,7 +35,7 @@ import itertools
 import pytesmo.temporal_matching as temp_match
 
 import pandas as pd
-
+from distutils.version import LooseVersion
 
 class BasicTemporalMatching(object):
     """
@@ -67,8 +67,11 @@ class BasicTemporalMatching(object):
         matched_data = pd.DataFrame(reference)
 
         for match in matched_datasets:
-#             match = match.drop(('index', ''), axis=1)
-            match = match.drop('index', axis=1)
+            if LooseVersion(pd.__version__) < LooseVersion('0.23'):
+                match = match.drop(('index', ''), axis=1)
+            else:
+                match = match.drop('index', axis=1)
+                
             match = match.drop('distance', axis=1)
             matched_data = matched_data.join(match)
 

--- a/pytesmo/validation_framework/temporal_matchers.py
+++ b/pytesmo/validation_framework/temporal_matchers.py
@@ -67,7 +67,8 @@ class BasicTemporalMatching(object):
         matched_data = pd.DataFrame(reference)
 
         for match in matched_datasets:
-            match = match.drop(('index', ''), axis=1)
+#             match = match.drop(('index', ''), axis=1)
+            match = match.drop('index', axis=1)
             match = match.drop('distance', axis=1)
             matched_data = matched_data.join(match)
 

--- a/pytesmo/validation_framework/validation.py
+++ b/pytesmo/validation_framework/validation.py
@@ -13,7 +13,7 @@ from pytesmo.validation_framework.data_manager import get_result_names
 from pytesmo.validation_framework.data_scalers import DefaultScaler
 import pytesmo.validation_framework.temporal_matchers as temporal_matchers
 from pytesmo.utils import ensure_iterable
-
+from distutils.version import LooseVersion
 
 class Validation(object):
 
@@ -267,8 +267,10 @@ class Validation(object):
 
                 # at this stage we can drop the column multiindex and just use
                 # the dataset name
-#                 data.columns = data.columns.droplevel(level=1)
-                data = data.rename(columns=lambda x: x[0])
+                if LooseVersion(pd.__version__) < LooseVersion('0.23'):
+                    data.columns = data.columns.droplevel(level=1)
+                else:
+                    data = data.rename(columns=lambda x: x[0])
 
                 if self.scaling is not None:
                     # get scaling index by finding the column in the

--- a/pytesmo/validation_framework/validation.py
+++ b/pytesmo/validation_framework/validation.py
@@ -267,7 +267,8 @@ class Validation(object):
 
                 # at this stage we can drop the column multiindex and just use
                 # the dataset name
-                data.columns = data.columns.droplevel(level=1)
+#                 data.columns = data.columns.droplevel(level=1)
+                data = data.rename(columns=lambda x: x[0])
 
                 if self.scaling is not None:
                     # get scaling index by finding the column in the


### PR DESCRIPTION
This is my attempt at fixing #136 

These two one-line-changes make the unit tests pass. WARNING: However, I'm not sure if I completely understand what the code is doing and what changed.

My understanding is that the problems come from two errors at two places in the code:

pytesmo/validation_framework/temporal_matchers.py:70
E   KeyError: "[('index', '')] not found in axis"

and

pytesmo/validation_framework/validation.py:270
E   AttributeError: 'Index' object has no attribute 'droplevel'

I guess they occur because Pandas changed the way it creates column names. In the matcher case, the column name is ('index', '') with pandas 0.22 and just 'index' with pandas 0.23. In the validation case, pandas 0.22 produces a MultiIndex while pandas 0.23 produces a simple Index with tuples as column names.

The changes I propose make pytesmo work with pandas 0.23 - but NOT with 0.22 (not downward compatible). To do that, one would have to investigate the column name creation, I guess.

I hope this helps...