### PR TITLE
typo fix: conda

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -165,7 +165,7 @@ Windows and Linux.
 .. code::
 
    conda create -n pytesmo -c conda-forge python=2.7 numpy scipy pandas netCDF4 cython pytest pip matplotlib pyproj
-   source activate test
+   source activate pytesmo
    pip install pygeogrids
    pip install pyresample
    pip install pytesmo


### PR DESCRIPTION
activate `pytesmo` env instead of `test`