### PR TITLE
Add Python 3.7 and remove 3.5 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
 
   - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy pandas netCDF4 cython pytest pip matplotlib pykdtree pyresample cartopy
   - source activate test-environment
+  - pip install pybufr-ecmwf
   - pip install pygeogrids
   - pip install pygeobase
   - pip install ascat

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy pandas netCDF4 cython pytest pip matplotlib pybufr-ecmwf pykdtree pyresample cartopy
+  - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy pandas netCDF4 cython pytest pip matplotlib pykdtree pyresample cartopy
   - source activate test-environment
   - pip install pygrib==1.9.9
   - pip install pygeogrids

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ install:
 
   - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy pandas netCDF4 cython pytest pip matplotlib pykdtree pyresample cartopy
   - source activate test-environment
-  - pip install pygrib==1.9.9
   - pip install pygeogrids
   - pip install pygeobase
   - pip install ascat

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 dist: xenial
+services:
+  - xvfb
 language: python
 sudo: false
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 before_script:
@@ -15,8 +16,8 @@ notifications:
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.7"
 install:
   # You may want to periodically update this, although the conda update
   # conda line below will keep everything up-to-date.  We do this

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,16 +16,6 @@ environment:
       PYTHON_ARCH: "64"
       MINICONDA_VERSION: "2"
 
-    - PYTHON: "C:\\Python35_32"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "32"
-      MINICONDA_VERSION: "3"
-
-    - PYTHON: "C:\\Python35_64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      MINICONDA_VERSION: "3"
-
     - PYTHON: "C:\\Python36_32"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "32"
@@ -33,6 +23,16 @@ environment:
 
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      MINICONDA_VERSION: "3"
+
+    - PYTHON: "C:\\Python37_32"
+      PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "32"
+      MINICONDA_VERSION: "3"
+
+    - PYTHON: "C:\\Python37_64"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       MINICONDA_VERSION: "3"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,20 +6,10 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
 
   matrix:
-    - PYTHON: "C:\\Python27_32"
-      PYTHON_VERSION: "2.7.8"
-      PYTHON_ARCH: "32"
-      MINICONDA_VERSION: "2"
-
     - PYTHON: "C:\\Python27_64"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "64"
       MINICONDA_VERSION: "2"
-
-    - PYTHON: "C:\\Python36_32"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
-      MINICONDA_VERSION: "3"
 
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"


### PR DESCRIPTION
Update CI a bit.

Dropped Python 3.5 testing and added 3.7. 

For Windows build I had to drop older 32 bit versions since the conda packages of the necessary netcdf4 version do not exist. But I'm not sure if anybody is actually using a 32 bit system.