### PR TITLE
copy mask in resample_to_grid(), thus preventing it to get modified during iterations

### DIFF
--- a/pytesmo/grid/resample.py
+++ b/pytesmo/grid/resample.py
@@ -266,7 +266,7 @@ def resample_to_grid(input_data, src_lon, src_lat, target_lon, target_lat,
                 target_lat.shape, dtype=orig_data.dtype) + fill_value
         else:
             output_array = np.zeros(target_lat.shape, dtype=orig_data.dtype)
-            output_array = np.ma.array(output_array, mask=mask)
+            output_array = np.ma.array(output_array, mask=mask.copy())
         output_array[~mask] = data
 
         output_data[param] = output_array.reshape(output_shape)


### PR DESCRIPTION
**Issue:** Currently `mask` is used to generate a masked array each loop. However, if `data` in 270: `output_array[~mask] = data` contains nan values, the mask of `output array` will change, and by extensions also the original `mask`. Therefore in subsequent  loop iterations `mask` will be different.

**Fix:** Just passing a copy of `mask` prevents it from changing between iterations.