### PR TITLE
CI: Include builds for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ python:
   - "2.7"
   - "3.6"
   - "3.7"
+  - "3.8"
 install:
   # You may want to periodically update this, although the conda update
   # conda line below will keep everything up-to-date.  We do this

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,10 @@ environment:
       PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
       MINICONDA: "C:\\Miniconda37-x64"
+    - PYTHON_ARCH: 64
+      PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8"
+      MINICONDA: "C:\\Miniconda37-x64"
 
 
 install:

--- a/pytesmo/timedate/julian.py
+++ b/pytesmo/timedate/julian.py
@@ -131,6 +131,10 @@ def julian2date(julian):
     min_julian = 2299160
     max_julian = 1827933925
 
+    is_single_value = False
+    if type(julian) in (float, int):
+        is_single_value = True
+
     julian = np.atleast_1d(np.array(julian, dtype=float))
 
     if np.min(julian) < min_julian or np.max(julian) > max_julian:
@@ -164,6 +168,11 @@ def julian2date(julian):
     microsecond = ((second - np.int32(second)) * 1e6).astype(np.int32)
     microsecond = microsecond.clip(min=0, max=999999)
     second = second.astype(np.int32)
+
+    if is_single_value:
+        (year, month, day, hour,
+         minute, second, microsecond) = (year.item(), month.item(), day.item(), hour.item(),
+                                         minute.item(), second.item(), microsecond.item())
 
     return year, month, day, hour, minute, second, microsecond
 

--- a/tests/test_timedate/test_julian.py
+++ b/tests/test_timedate/test_julian.py
@@ -87,6 +87,7 @@ def test_caldat_array():
 def test_julian2date():
     (year, month, day,
      hour, minute, second, micro) = julian2date(2457533.9306828701)
+    assert type(year) == int
     assert year == 2016
     assert month == 5
     assert day == 25


### PR DESCRIPTION
Had to change a small think in julian date conversion. Since values where returned as arrays when a single float value was the input