### PR TITLE
Val Framework compares dataset matches that do not include the temporal reference

### DIFF
--- a/src/pytesmo/validation_framework/data_manager.py
+++ b/src/pytesmo/validation_framework/data_manager.py
@@ -387,6 +387,33 @@ def flatten(seq):
     return l
 
 
+def get_result_combinations(ds_dict, n=2):
+    """
+    Get all possible combinations dataset columns
+
+    Parameters
+    ----------
+    ds_dict: dict
+       Dict of lists containing the dataset names as keys and a list of the
+       columns to read from the dataset as values.
+    n: int
+        Number of datasets for combine with each other.
+        If n=2 always two datasets will be combined into one result.
+        If n=3 always three datasets will be combined into one results and so on.
+        n has to be <= the number of total datasets.
+
+    Returns
+    -------
+    results_names : list of tuples
+        Containing all possible combinations of
+        (dataset_x.column, dataset_y.column)
+        for all datasets in ds_dict
+    """
+    combis = []
+    for key in ds_dict:
+        combis.extend(get_result_names(ds_dict, key, n=n))
+    return sorted(list(set(combis)))
+
 def get_result_names(ds_dict, refkey, n=2):
     """
     Return result names based on all possible combinations based on a
@@ -444,6 +471,6 @@ def get_result_names(ds_dict, refkey, n=2):
             continue
         for dataset, column in zip(datasets, columns):
             combo.append((dataset, column))
-        result_combos.append(tuple(combo))
+        result_combos.append(tuple(sorted(combo)))
 
     return result_combos

--- a/src/pytesmo/validation_framework/temporal_matchers.py
+++ b/src/pytesmo/validation_framework/temporal_matchers.py
@@ -71,7 +71,7 @@ class BasicTemporalMatching(object):
                 match = match.drop(('index', ''), axis=1)
             else:
                 match = match.drop('index', axis=1)
-                
+
             match = match.drop('distance', axis=1)
             matched_data = matched_data.join(match)
 

--- a/tests/test_validation_framwork/test_data_manager.py
+++ b/tests/test_validation_framwork/test_data_manager.py
@@ -39,6 +39,7 @@ from pygeobase.io_base import GriddedTsBase
 
 from pytesmo.validation_framework.data_manager import DataManager
 from pytesmo.validation_framework.data_manager import get_result_names
+from pytesmo.validation_framework.data_manager import get_result_combinations
 
 from tests.test_validation_framwork.test_datasets import TestDataset
 from tests.test_validation_framwork.test_datasets import setup_TestDatasets
@@ -227,6 +228,22 @@ def test_get_result_names():
                             (('DS1', 'soil moisture'), ('DS3', 'sm2'))]
 
     result_names = get_result_names(tst_ds_dict, 'DS2', 2)
-    assert result_names == [(('DS2', 'sm'), ('DS1', 'soil moisture')),
+    assert result_names == [(('DS1', 'soil moisture'), ('DS2', 'sm')),
+                            (('DS2', 'sm'), ('DS3', 'sm')),
+                            (('DS2', 'sm'), ('DS3', 'sm2'))]
+
+def test_get_result_combinations():
+
+    tst_ds_dict = {'DS1': ['soil moisture'],
+                   'DS2': ['sm'],
+                   'DS3': ['sm', 'sm2']}
+    result_names = get_result_combinations(tst_ds_dict, n=3)
+    assert result_names == [(('DS1', 'soil moisture'), ('DS2', 'sm'), ('DS3', 'sm')),
+                            (('DS1', 'soil moisture'), ('DS2', 'sm'), ('DS3', 'sm2'))]
+
+    result_names = get_result_combinations(tst_ds_dict, n=2)
+    assert result_names == [(('DS1', 'soil moisture'), ('DS2', 'sm')),
+                            (('DS1', 'soil moisture'), ('DS3', 'sm')),
+                            (('DS1', 'soil moisture'), ('DS3', 'sm2')),
                             (('DS2', 'sm'), ('DS3', 'sm')),
                             (('DS2', 'sm'), ('DS3', 'sm2'))]

--- a/tests/test_validation_framwork/test_validation.py
+++ b/tests/test_validation_framwork/test_validation.py
@@ -289,68 +289,23 @@ def test_ascat_ismn_validation_metadata():
                             sorted(results.variables['network'][:]))
 
 
-def test_validation_n2_k2():
-
-    tst_results = {
-        (('DS1', 'x'), ('DS3', 'y')): {
-            'n_obs': np.array([1000], dtype=np.int32),
-            'tau': np.array([np.nan], dtype=np.float32),
-            'gpi': np.array([4], dtype=np.int32),
-            'RMSD': np.array([0.], dtype=np.float32),
-            'lon': np.array([4.]),
-            'p_tau': np.array([np.nan], dtype=np.float32),
-            'BIAS': np.array([0.], dtype=np.float32),
-            'p_rho': np.array([0.], dtype=np.float32),
-            'rho': np.array([1.], dtype=np.float32),
-            'lat': np.array([4.]),
-            'R': np.array([1.], dtype=np.float32),
-            'p_R': np.array([0.], dtype=np.float32)},
-        (('DS1', 'x'), ('DS2', 'y')): {
-            'n_obs': np.array([1000], dtype=np.int32),
-            'tau': np.array([np.nan], dtype=np.float32),
-            'gpi': np.array([4], dtype=np.int32),
-            'RMSD': np.array([0.], dtype=np.float32),
-            'lon': np.array([4.]),
-            'p_tau': np.array([np.nan], dtype=np.float32),
-            'BIAS': np.array([0.], dtype=np.float32),
-            'p_rho': np.array([0.], dtype=np.float32),
-            'rho': np.array([1.], dtype=np.float32),
-            'lat': np.array([4.]),
-            'R': np.array([1.], dtype=np.float32),
-            'p_R': np.array([0.], dtype=np.float32)},
-        (('DS1', 'x'), ('DS3', 'x')): {
-            'n_obs': np.array([1000], dtype=np.int32),
-            'tau': np.array([np.nan], dtype=np.float32),
-            'gpi': np.array([4], dtype=np.int32),
-            'RMSD': np.array([0.], dtype=np.float32),
-            'lon': np.array([4.]),
-            'p_tau': np.array([np.nan], dtype=np.float32),
-            'BIAS': np.array([0.], dtype=np.float32),
-            'p_rho': np.array([0.], dtype=np.float32),
-            'rho': np.array([1.], dtype=np.float32),
-            'lat': np.array([4.]),
-            'R': np.array([1.], dtype=np.float32),
-            'p_R': np.array([0.], dtype=np.float32)}}
+def test_validation_error_n2_k2():
 
     datasets = setup_TestDatasets()
 
     dm = DataManager(datasets, 'DS1', read_ts_names={d: 'read' for d in ['DS1', 'DS2', 'DS3']})
 
-    process = Validation(
-        dm, 'DS1',
-        temporal_matcher=temporal_matchers.BasicTemporalMatching(
-            window=1 / 24.0).combinatory_matcher,
-        scaling='lin_cdf_match',
-        metrics_calculators={
-            (2, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
+    # n less than number of datasets is no longer allowed
+    with pytest.raises(ValueError):
+        process = Validation(
+            dm, 'DS1',
+            temporal_matcher=temporal_matchers.BasicTemporalMatching(
+                window=1 / 24.0).combinatory_matcher,
+            scaling='lin_cdf_match',
+            metrics_calculators={
+                (2, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
 
-    jobs = process.get_processing_jobs()
-    for job in jobs:
-        results = process.calc(*job)
-        assert sorted(list(results)) == sorted(list(tst_results))
-
-
-def test_validation_n2_k2_temporal_matching_no_matches():
+def test_validation_n3_k2_temporal_matching_no_matches():
 
     tst_results = {}
 
@@ -365,7 +320,7 @@ def test_validation_n2_k2_temporal_matching_no_matches():
             window=1 / 24.0).combinatory_matcher,
         scaling='lin_cdf_match',
         metrics_calculators={
-            (2, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
+            (3, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
 
     jobs = process.get_processing_jobs()
     for job in jobs:
@@ -373,7 +328,7 @@ def test_validation_n2_k2_temporal_matching_no_matches():
         assert sorted(list(results)) == sorted(list(tst_results))
 
 
-def test_validation_n2_k2_data_manager_argument():
+def test_validation_n3_k2_data_manager_argument():
 
     tst_results = {
         (('DS1', 'x'), ('DS3', 'y')): {
@@ -414,7 +369,49 @@ def test_validation_n2_k2_data_manager_argument():
             'rho': np.array([1.], dtype=np.float32),
             'lat': np.array([4.]),
             'R': np.array([1.], dtype=np.float32),
-            'p_R': np.array([0.], dtype=np.float32)}}
+            'p_R': np.array([0.], dtype=np.float32)},
+        (('DS2', 'y'), ('DS3', 'x')): {
+            'gpi': np.array([4], dtype=np.int32),
+            'lon': np.array([4.]),
+            'lat': np.array([4.]),
+            'n_obs': np.array([1000], dtype=np.int32),
+            'R': np.array([1.], dtype=np.float32),
+            'p_R': np.array([0.], dtype=np.float32),
+            'rho': np.array([1.], dtype=np.float32),
+            'p_rho': np.array([0.], dtype=np.float32),
+            'RMSD': np.array([0.], dtype=np.float32),
+            'BIAS': np.array([0.], dtype=np.float32),
+            'tau': np.array([np.nan], dtype=np.float32),
+            'p_tau': np.array([np.nan], dtype=np.float32)},
+        (('DS2', 'y'), ('DS3', 'y')): {
+            'gpi': np.array([4], dtype=np.int32),
+            'lon': np.array([4.]),
+            'lat': np.array([4.]),
+            'n_obs': np.array([1000], dtype=np.int32),
+            'R': np.array([1.], dtype=np.float32),
+            'p_R': np.array([0.], dtype=np.float32),
+            'rho': np.array([1.], dtype=np.float32),
+            'p_rho': np.array([0.], dtype=np.float32),
+            'RMSD': np.array([0.], dtype=np.float32),
+            'BIAS': np.array([0.], dtype=np.float32),
+            'tau': np.array([np.nan], dtype=np.float32),
+            'p_tau': np.array([np.nan], dtype=np.float32)}}
+
+    datasets = setup_TestDatasets()
+    dm = DataManager(datasets, 'DS1', read_ts_names={d: 'read' for d in ['DS1', 'DS2', 'DS3']})
+
+    process = Validation(
+        dm, 'DS1',
+        temporal_matcher=temporal_matchers.BasicTemporalMatching(
+            window=1 / 24.0).combinatory_matcher,
+        scaling='lin_cdf_match',
+        metrics_calculators={
+            (3, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
+
+    jobs = process.get_processing_jobs()
+    for job in jobs:
+        results = process.calc(*job)
+        assert sorted(list(results)) == sorted(list(tst_results))
 
     datasets = setup_TestDatasets()
     dm = DataManager(datasets, 'DS1', read_ts_names={d: 'read' for d in ['DS1', 'DS2', 'DS3']})
@@ -424,7 +421,7 @@ def test_validation_n2_k2_data_manager_argument():
                              window=1 / 24.0).combinatory_matcher,
                          scaling='lin_cdf_match',
                          metrics_calculators={
-                             (2, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
+                             (3, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
 
     jobs = process.get_processing_jobs()
     for job in jobs:
@@ -473,7 +470,33 @@ def test_validation_n3_k2():
             'rho': np.array([1.], dtype=np.float32),
             'lat': np.array([4.]),
             'R': np.array([1.], dtype=np.float32),
-            'p_R': np.array([0.], dtype=np.float32)}}
+            'p_R': np.array([0.], dtype=np.float32)},
+        (('DS2', 'y'), ('DS3', 'x')): {
+            'gpi': np.array([4], dtype=np.int32),
+            'lon': np.array([4.]),
+            'lat': np.array([4.]),
+            'n_obs': np.array([1000], dtype=np.int32),
+            'R': np.array([1.], dtype=np.float32),
+            'p_R': np.array([0.], dtype=np.float32),
+            'rho': np.array([1.], dtype=np.float32),
+            'p_rho': np.array([0.], dtype=np.float32),
+            'RMSD': np.array([0.], dtype=np.float32),
+            'BIAS': np.array([0.], dtype=np.float32),
+            'tau': np.array([np.nan], dtype=np.float32),
+            'p_tau': np.array([np.nan], dtype=np.float32)},
+        (('DS2', 'y'), ('DS3', 'y')): {
+            'gpi': np.array([4], dtype=np.int32),
+            'lon': np.array([4.]),
+            'lat': np.array([4.]),
+            'n_obs': np.array([1000], dtype=np.int32),
+            'R': np.array([1.], dtype=np.float32),
+            'p_R': np.array([0.], dtype=np.float32),
+            'rho': np.array([1.], dtype=np.float32),
+            'p_rho': np.array([0.], dtype=np.float32),
+            'RMSD': np.array([0.], dtype=np.float32),
+            'BIAS': np.array([0.], dtype=np.float32),
+            'tau': np.array([np.nan], dtype=np.float32),
+            'p_tau': np.array([np.nan], dtype=np.float32)}}
 
     datasets = setup_TestDatasets()
     dm = DataManager(datasets, 'DS1', read_ts_names={d: 'read' for d in ['DS1', 'DS2', 'DS3']})
@@ -531,7 +554,7 @@ def test_validation_n3_k2_temporal_matching_no_matches():
             window=1 / 24.0).combinatory_matcher,
         scaling='lin_cdf_match',
         metrics_calculators={
-            (2, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
+            (3, 2): metrics_calculators.BasicMetrics(other_name='k1').calc_metrics})
 
     jobs = process.get_processing_jobs()
     for job in jobs:
@@ -606,6 +629,10 @@ def test_validation_n3_k2_masking():
         (('DS1', 'x'), ('DS2', 'y')): {
             'n_obs': np.array([250], dtype=np.int32)},
         (('DS1', 'x'), ('DS3', 'x')): {
+            'n_obs': np.array([250], dtype=np.int32)},
+        (('DS2', 'y'), ('DS3', 'x')): {
+            'n_obs': np.array([250], dtype=np.int32)},
+        (('DS2', 'y'), ('DS3', 'y')): {
             'n_obs': np.array([250], dtype=np.int32)}}
 
     # test result for two gpis in a cell
@@ -615,6 +642,10 @@ def test_validation_n3_k2_masking():
         (('DS1', 'x'), ('DS2', 'y')): {
             'n_obs': np.array([250, 250], dtype=np.int32)},
         (('DS1', 'x'), ('DS3', 'x')): {
+            'n_obs': np.array([250, 250], dtype=np.int32)},
+        (('DS2', 'y'), ('DS3', 'x')): {
+            'n_obs': np.array([250, 250], dtype=np.int32)},
+        (('DS2', 'y'), ('DS3', 'y')): {
             'n_obs': np.array([250, 250], dtype=np.int32)}}
 
     # cell 4 in this example has two gpis so it returns different results.


### PR DESCRIPTION
This changes the behavior of the validation framework.

Before this a validation run with `(n, k)` where `k < n` only gave results for
combinations of datasets which included the temporal reference.

e.g. If 3 dataset (DS1, DS2 and DS3) where given and a metric calculator was run
with `(3, 2)` with the temporal reference DS1. Then only the combinations of
`DS1 - DS2` and `DS1 - DS3` gave results.

This rectifies this behavior to also return results for the combination `DS2 -
DS3` in the above example.

Tests still need to be adapted but I want to discuss this first to see if this
is what people expect.

There are also some edge cases. e.g. If 4 datasets are given but the
configuration of the metric calculator would be `(3, 2)`. I think we should
raise an error in these cases because that would mean that the temporal
reference is not included in all matches.