### PR TITLE
Adding AdvancedMaskingAdapter and test

### DIFF
--- a/pytesmo/validation_framework/adapters.py
+++ b/pytesmo/validation_framework/adapters.py
@@ -160,6 +160,68 @@ class SelfMaskingAdapter(BasicAdapter):
         data = super(SelfMaskingAdapter, self).read(*args, **kwargs)
         return self.__mask(data)
 
+
+class AdvancedMaskingAdapter(BasicAdapter):
+    """
+    Transform the given (reader) class to return a dataset that is masked based
+    on the given list of filters. A filter is a 3-tuple of column_name, operator, and threshold.
+    This class calls the read_ts or read method of the given reader instance, applies all filters
+    separately, ANDs all filters together, and masks the whole dataframe with the result.
+
+    Parameters
+    ----------
+    cls: object
+        has to have a read_ts or read method
+    filter_list: list of 3-tuples: column_name, operator, and threshold.
+        'column_name': string
+            name of the column to apply the operator to
+        'operator': callable or string;
+            callable needs to accept two parameters (e.g. my_mask(a,b);
+            the threshold will be passed to the second parameter
+            string needs to be one of '<', '<=', '==', '>=', '>', '!='
+        'threshold':
+            value to use as the threshold combined with the operator;
+    """
+
+    def __init__(self, cls, filter_list):
+        super(AdvancedMaskingAdapter, self).__init__(cls)
+
+        self.op_lookup = {'<': operator.lt,
+                          '<=': operator.le,
+                          '==': operator.eq,
+                          '!=': operator.ne,
+                          '>=': operator.ge,
+                          '>': operator.gt}
+
+        self.filter_list = filter_list
+
+    def __mask(self, data):
+        mask = None
+        for column_name, op, threshold in self.filter_list:
+            if callable(op):
+                operator = op
+            elif op in self.op_lookup:
+                operator = self.op_lookup[op]
+            else:
+                raise ValueError('"{}" is not a valid operator'.format(op))
+
+            new_mask = operator(data[column_name], threshold)
+
+            if mask is not None:
+                mask = mask & new_mask
+            else:
+                mask = new_mask
+
+        return data[mask]
+
+    def read_ts(self, *args, **kwargs):
+        data = super(AdvancedMaskingAdapter, self).read_ts(*args, **kwargs)
+        return self.__mask(data)
+
+    def read(self, *args, **kwargs):
+        data = super(AdvancedMaskingAdapter, self).read(*args, **kwargs)
+        return self.__mask(data)
+
 class AnomalyAdapter(BasicAdapter):
     """
     Takes the pandas DataFrame that the read_ts or read method of the instance


### PR DESCRIPTION
This PR adds an AdvancedMaskingAdapter that can be used to mask the data from a reader based on a list of filters. The list must contain 3-tuples of filter parameter: data column to filter on, operator to use and threshold to use. Operator can either be taken from a pre-defined list (same as in MaskingAdapter) or be a user-defined callable.
We'd like to use it in QA4SM to implement complex masking for SMOS data and think that it'll be useful in pytesmo in general.

Example of SMOS filter:

    filtered_reader = AdvancedMaskingAdapter(reader, [
        ('Scene_Flags', smos_exclude_bitmask, 0b00001000), 
        ('Soil_Temperature_Level1', '>=', 273), ])        

(where `smos_exclude_bitmask` is a user-defined function)