### PR TITLE
Updates for qa4sm and ISMN paper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ tags
 # Unittest and coverage
 htmlcov/*
 .coverage
+.coverage*
 .tox
 junit.xml
 coverage.xml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,10 @@ Changelog
 Unreleased
 ==========
 
--
+- Include more combinations in validation framework, raise error if n < n_datasets
+- Correlation coefficients not ignore nans in arrays
+- TC metrics calculator has not option to calculate metrics for reference
+- Fix deprecation warnings in anomaly adapter (#198)
 
 
 Version 0.9, 2020-07-02

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,16 @@ Changelog
 Unreleased
 ==========
 
+-
+
+Version 0.9.1, 2020-09-14
+=========================
+
 - Include more combinations in validation framework, raise error if n < n_datasets
-- Correlation coefficients not ignore nans in arrays
-- TC metrics calculator has not option to calculate metrics for reference
-- Fix deprecation warnings in anomaly adapter (#198)
+- `n_wise_apply` now can handle (drop) nans in a passed data frame correctly.
+- TC metrics calculator has now option to calculate metrics for reference
+- Fix deprecation warnings in anomaly adapter (Issue #198)
+- Change combinations created by val framework, catch cases where scaling ref not in combinations (Issue #187)
 
 
 Version 0.9, 2020-07-02

--- a/src/pytesmo/df_metrics.py
+++ b/src/pytesmo/df_metrics.py
@@ -40,6 +40,7 @@ from collections.abc import Iterable
 import itertools
 import pandas as pd
 import warnings
+from pytesmo.utils import array_dropna
 
 def n_combinations(iterable, n, must_include=None, permutations=False):
     """
@@ -448,8 +449,7 @@ def nwise_apply(df, method, n=2, comm=False, as_df=False, ds_names=True,
     # find out how many variables the applyf returns
     result = []
     # apply the method using the first data set to find out the shape of c,
-    # we add a bias (i) to avoid raising warnings.
-    c = applyf(*[mat[i] for i in range(n)])
+    c = applyf(*array_dropna(*[mat[i] for i in range(n)]))
     for index, value in enumerate(np.atleast_1d(c)):
         result.append(OrderedDict([(c, np.nan) for c in combs]))
     result = np.array(result)    # array of OrderedDicts

--- a/src/pytesmo/metrics.py
+++ b/src/pytesmo/metrics.py
@@ -31,6 +31,7 @@ from __future__ import division
 import numpy as np
 import scipy.stats as sc_stats
 from itertools import permutations,combinations
+from pytesmo.utils import array_dropna
 
 def bias(x, y):
     """
@@ -569,29 +570,29 @@ def RSS(o, p):
 
 
 def pearsonr(x, y):
-    """
-    Wrapper for scipy.stats.pearsonr. Calculates a Pearson correlation
-    coefficient and the p-value for testing non-correlation.
+   """
+   Wrapper for scipy.stats.pearsonr. Calculates a Pearson correlation
+   coefficient and the p-value for testing non-correlation.
 
-    Parameters
-    ----------
-    x : numpy.ndarray
-        First input vector.
-    y : numpy.ndarray
-        Second input vector.
+   Parameters
+   ----------
+   x : numpy.ndarray
+       First input vector.
+   y : numpy.ndarray
+       Second input vector.
 
-    Returns
-    -------
-    r : float
-        Pearson's correlation coefficent.
-    p-value : float
-        2 tailed p-value.
+   Returns
+   -------
+   r : float
+       Pearson's correlation coefficent.
+   p-value : float
+       2 tailed p-value.
 
-    See Also
-    --------
-    scipy.stats.pearsonr
-    """
-    return sc_stats.pearsonr(x, y)
+   See Also
+   --------
+   scipy.stats.pearsonr
+   """
+   return sc_stats.pearsonr(x, y)
 
 @np.errstate(invalid='ignore')
 def pearsonr_recursive(x, y, n_old=0, sum_xi_yi=0,
@@ -695,9 +696,9 @@ def spearmanr(x, y):
 
     Parameters
     ----------
-    x : numpy.ndarray
+    x : numpy.array
         First input vector.
-    y : numpy.ndarray
+    y : numpy.array
         Second input vector.
 
     Returns
@@ -721,9 +722,9 @@ def kendalltau(x, y):
 
     Parameters
     ----------
-    x : numpy.ndarray
+    x : numpy.array
         First input vector.
-    y : numpy.ndarray
+    y : numpy.array
         Second input vector.
 
     Returns
@@ -738,7 +739,7 @@ def kendalltau(x, y):
     --------
     scipy.stats.kendalltau
     """
-    return sc_stats.kendalltau(x.tolist(), y.tolist())
+    return sc_stats.kendalltau(x, y)
 
 
 def index_of_agreement(o, p):

--- a/src/pytesmo/time_series/anomaly.py
+++ b/src/pytesmo/time_series/anomaly.py
@@ -4,7 +4,7 @@ Created on June 20, 2013
 
 import pandas as pd
 import numpy as np
-from pytesmo.timedate.julian import doy
+from cadati.conv_doy import doy
 from cadati.jd_date import julian2date
 from pytesmo.time_series.filtering import moving_average
 

--- a/src/pytesmo/utils.py
+++ b/src/pytesmo/utils.py
@@ -251,3 +251,25 @@ def ensure_iterable(el):
         return [el]
     else:
         return el
+
+def array_dropna(*arrs):
+    """
+    Drop elements from input arrays where ANY array is NaN
+
+    Parameters
+    ----------
+    *arrs : np.array(s)
+        One or multiple numpy arrays of the same length that contain nans
+
+    Returns
+    -------
+    arrs_dropna : np.array
+        Input arrays without NaNs
+    """
+
+    idx = ~np.logical_or(*[np.isnan(x) for x in arrs])
+    arrs_dropna = [np.compress(idx, x) for x in arrs]
+
+    if len(arrs_dropna) == 1: arrs_dropna = arrs_dropna[0]
+
+    return tuple(arrs_dropna)

--- a/src/pytesmo/validation_framework/metric_calculators.py
+++ b/src/pytesmo/validation_framework/metric_calculators.py
@@ -642,6 +642,9 @@ class IntercomparisonMetrics(MetadataMetrics):
         if True then also tau is calculated. This is set to False by default
         since the calculation of Kendalls tau is rather slow and can significantly
         impact performance of e.g. global validation studies
+    metrics_between_nonref : bool, optional (default: False)
+        Allow 2-dataset combinations where the ref is not included.
+        Warning: can lead to many combinations.
     dataset_names : list, optional (default: None)
         Names of the original datasets, that are used to find the lookup table
         for the df cols.
@@ -651,6 +654,7 @@ class IntercomparisonMetrics(MetadataMetrics):
     """
 
     def __init__(self, other_names=('k1', 'k2', 'k3'), calc_tau=False,
+                 metrics_between_nonref=False,
                  dataset_names=None, metadata_template=None):
 
         other_names = list(other_names)
@@ -674,7 +678,9 @@ class IntercomparisonMetrics(MetadataMetrics):
         for name, col in zip(self.ds_names, self.df_columns):
             self.ds_names_lut[col] = name
 
-        combis = n_combinations(self.df_columns, 2, must_include='ref')
+        combis = n_combinations(self.df_columns, 2,
+            must_include='ref' if not metrics_between_nonref else None)
+
         self.tds_names = []
         for combi in combis:
             self.tds_names.append("{1}{0}{2}".format(

--- a/src/pytesmo/validation_framework/metric_calculators.py
+++ b/src/pytesmo/validation_framework/metric_calculators.py
@@ -833,7 +833,7 @@ class TCMetrics(MetadataMetrics):
     """
 
     def __init__(self, other_names=('k1', 'k2'), calc_tau=False, dataset_names=None,
-                 metadata_template=None):
+                 tc_metrics_for_ref=True, metadata_template=None):
         """
         Triple Collocation metrics as implemented in the QA4SM project.
 
@@ -846,6 +846,8 @@ class TCMetrics(MetadataMetrics):
         dataset_names : tuple, optional (default: None)
             List that maps the names of the satellite dataset columns to their
             real name that will be used in the results file.
+        tc_metrics_for_ref : bool, optional (default: False)
+            Store TC metrics for the reference data sets as well.
         metadata_template: dictionary, optional
             A dictionary containing additional fields (and types) of the form
             dict = {'field': np.float32([np.nan]}. Allows users to specify
@@ -888,8 +890,10 @@ class TCMetrics(MetadataMetrics):
 
         metrics_common = _get_metric_template(metrics_common)
         metrics_tds = _get_metric_template(metrics_tds)
+
+        ignore_ds = [self.ref_name] if not tc_metrics_for_ref else ()
         metrics_thds = _get_tc_metric_template(metrics_thds,
-                                               [self.ds_names_lut[n] for n in self.df_columns if n != self.ref_name])
+            [self.ds_names_lut[n] for n in self.df_columns if n not in ignore_ds])
 
         for metric in metrics_common.keys():
             self.result_template[metric] = metrics_common[metric].copy()

--- a/tests/test_df_metrics.py
+++ b/tests/test_df_metrics.py
@@ -6,7 +6,7 @@ of columns from a data frame.
 """
 
 import pytesmo.df_metrics as df_metrics
-from pytesmo.metrics import bias
+from pytesmo.metrics import bias, pearsonr
 import pandas as pd
 import numpy as np
 
@@ -23,8 +23,11 @@ def test_apply():
 
     df = pd.DataFrame(index=pd.date_range(start='2000-01-01', end='2000-12-31', freq='D'),
                       data={'ds0': np.repeat(0, 366), 'ds1': np.repeat(1, 366)})
+    df.loc[df.index[np.random.choice(range(366), 10)], 'ds0'] = np.nan
+    df.loc[df.index[np.random.choice(range(366), 10)], 'ds1'] = np.nan
     bias_matrix_old = df_metrics.pairwise_apply(df, bias)
     bias_matrix_new = df_metrics.nwise_apply(df, bias,  n=2, as_df=True)
+    r_matrix_new = df_metrics.nwise_apply(df, pearsonr,  n=2, as_df=True)
     assert bias_matrix_old.equals(bias_matrix_new)
 
     # check if dict implementation and matrix implementation have same result
@@ -38,3 +41,5 @@ def test_dict_to_namedtuple():
     assert d_named._fields == ('a', 'b')
     assert type(d_named).__name__ == 'name'
 
+if __name__ == '__main__':
+    test_apply()


### PR DESCRIPTION
- Include more combinations in validation framework, raise error if n < n_datasets
- `n_wise_apply` now can handle (drop) nans in a passed data frame correctly.
- TC metrics calculator has now option to calculate metrics for reference
- Fix deprecation warnings in anomaly adapter (Issue #198)