### PR TITLE
New temporal matching/collocation implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ will clone test-data, which is needed by some tests.
     $ cd pytesmo
     $ conda create -n pytesmo python=3.6 # or any supported python version
     $ source activate pytesmo
-    $ conda update -f environment.yml -n pytesmo
+    $ conda env update -f environment.yml -n pytesmo
     $ python setup.py develop
 
 .. note::

--- a/docs/examples/temporal_collocation.ipynb
+++ b/docs/examples/temporal_collocation.ipynb
@@ -1,0 +1,518 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why is temporal collocation important?\n",
+    "\n",
+    "Satellite observations usually have an irregular temporal sampling pattern (intervals between 6-36 hours), which is mostly controlled by the orbit of the satellite and the instrument measurement geometry. On the other hand, in-situ instruments or land surface models generally sample on regular time intervals (commonly every 1, 3, 6, 12 or 24 hours). \n",
+    "In order to compute error/performance statistics (such as RMSD, bias, correlation) between the time series coming from different sources, it is required that observation pairs (or triplets, etc.) are found which (nearly) coincide in time.\n",
+    "\n",
+    "A simple way to identify such pairs is by using a nearest neighbor search. First, one time series needs to be selected as temporal reference (i.e. all other time series will be matched to this reference) and second, a tolerance window (typically around 1-12 hours) has to be defined characterizing the temporal correlation of neighboring observation (i.e. observations outside of the tolerance window are no longer be considered as representative neighbors). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Temporal collocation in pytesmo\n",
+    "\n",
+    "Pytesmo contains the function `pytesmo.temporal_matching.temporal_collocation` for nearest neighbour matching. It requires a reference index (can also be a DataFrame or a Series), a DataFrame (or Series) to be collocated, and a window.\n",
+    "\n",
+    "```\n",
+    "collocated = temporal_collocation(reference, input_frame, window)\n",
+    "```\n",
+    "\n",
+    "The window argument corresponds to the time intervals that are included in the nearest neighbour search in each direction, e.g. if the reference time is $t$ and the window $\\Delta$, the nearest neighbour inside $[t-\\Delta, t+\\Delta]$ is returned. If no neighbour is found `np.nan` is used as replacement. NaNs can be dropped from the returned dataframe by providing the optional keyword argument ``dropna=True`` to the function.\n",
+    "\n",
+    "Below are two simple examples which demonstrate the usage. The first example assumes that the index of data to be collocated is shifted by 3 hours with respect to the reference, while using a 6 hour window. The second example uses an index that is randomly shifted by $\\pm12$ hours with respect to the reference. The second example also uses a 6 hour window, which results in some missing values in the resulting dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                            0         1         2\n",
+      "2020-01-01 03:00:00  1.201342 -0.800769  0.401427\n",
+      "2020-01-02 03:00:00 -1.069162 -0.881217  0.778702\n",
+      "2020-01-03 03:00:00 -0.139476  0.533678  0.563714\n",
+      "2020-01-04 03:00:00 -0.697052 -2.088295  0.944217\n",
+      "2020-01-05 03:00:00  0.077201 -0.079829 -0.236811\n",
+      "...                       ...       ...       ...\n",
+      "2020-12-27 03:00:00 -0.888301 -0.851369 -1.850475\n",
+      "2020-12-28 03:00:00 -0.604062  0.294393 -0.566648\n",
+      "2020-12-29 03:00:00 -0.122994 -0.372023 -0.619184\n",
+      "2020-12-30 03:00:00 -1.486709  0.853604 -0.373724\n",
+      "2020-12-31 03:00:00 -2.053052 -0.833403  0.547443\n",
+      "\n",
+      "[366 rows x 3 columns]\n",
+      "                                      0         1         2\n",
+      "2020-01-01 10:10:05.882844000  1.201342 -0.800769  0.401427\n",
+      "2020-01-02 02:55:57.469022400 -1.069162 -0.881217  0.778702\n",
+      "2020-01-03 11:07:48.032410800 -0.139476  0.533678  0.563714\n",
+      "2020-01-04 07:05:18.389209200 -0.697052 -2.088295  0.944217\n",
+      "2020-01-04 15:08:30.166195200  0.077201 -0.079829 -0.236811\n",
+      "...                                 ...       ...       ...\n",
+      "2020-12-27 03:54:13.699969200 -0.888301 -0.851369 -1.850475\n",
+      "2020-12-28 09:05:22.153801200 -0.604062  0.294393 -0.566648\n",
+      "2020-12-29 10:50:29.937210000 -0.122994 -0.372023 -0.619184\n",
+      "2020-12-30 10:39:32.883933600 -1.486709  0.853604 -0.373724\n",
+      "2020-12-31 05:29:01.663018800 -2.053052 -0.833403  0.547443\n",
+      "\n",
+      "[366 rows x 3 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from pytesmo.temporal_matching import temporal_collocation\n",
+    "\n",
+    "# use 6 hour window for the examples\n",
+    "window = pd.Timedelta(hours=6)\n",
+    "\n",
+    "# create reference time series\n",
+    "ref = pd.date_range(\"2020-01-01\", \"2020-12-31\", freq=\"D\")\n",
+    "# temporal_collocation can also take a DataFrame or Series as reference input,\n",
+    "# in case their index is a DatetimeIndex.\n",
+    "\n",
+    "\n",
+    "# create other time series as dataframe\n",
+    "values = np.random.randn(len(ref), 3)\n",
+    "shifted = pd.DataFrame(values, index=ref + pd.Timedelta(hours=3))\n",
+    "random_shift = np.random.uniform(-12, 12, len(ref))\n",
+    "random = pd.DataFrame(values, index=ref + pd.to_timedelta(random_shift, \"H\"))\n",
+    "\n",
+    "print(shifted)\n",
+    "print(random)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                  0         1         2\n",
+      "2020-01-01 00:00:00+00:00  1.201342 -0.800769  0.401427\n",
+      "2020-01-02 00:00:00+00:00 -1.069162 -0.881217  0.778702\n",
+      "2020-01-03 00:00:00+00:00 -0.139476  0.533678  0.563714\n",
+      "2020-01-04 00:00:00+00:00 -0.697052 -2.088295  0.944217\n",
+      "2020-01-05 00:00:00+00:00  0.077201 -0.079829 -0.236811\n",
+      "...                             ...       ...       ...\n",
+      "2020-12-27 00:00:00+00:00 -0.888301 -0.851369 -1.850475\n",
+      "2020-12-28 00:00:00+00:00 -0.604062  0.294393 -0.566648\n",
+      "2020-12-29 00:00:00+00:00 -0.122994 -0.372023 -0.619184\n",
+      "2020-12-30 00:00:00+00:00 -1.486709  0.853604 -0.373724\n",
+      "2020-12-31 00:00:00+00:00 -2.053052 -0.833403  0.547443\n",
+      "\n",
+      "[366 rows x 3 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# match the regularly shifted data\n",
+    "matched_shifted = temporal_collocation(ref, shifted, window)\n",
+    "print(matched_shifted)\n",
+    "\n",
+    "# the data should be the same before and after matching\n",
+    "assert np.all(shifted.values == matched_shifted.values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                  0         1         2\n",
+      "2020-01-01 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-01-02 00:00:00+00:00 -1.069162 -0.881217  0.778702\n",
+      "2020-01-03 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-01-04 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-01-05 00:00:00+00:00       NaN       NaN       NaN\n",
+      "...                             ...       ...       ...\n",
+      "2020-12-27 00:00:00+00:00 -0.888301 -0.851369 -1.850475\n",
+      "2020-12-28 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-12-29 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-12-30 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-12-31 00:00:00+00:00 -2.053052 -0.833403  0.547443\n",
+      "\n",
+      "[366 rows x 3 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# match the randomly shifted data\n",
+    "matched_random = temporal_collocation(ref, random, window)\n",
+    "print(matched_random)\n",
+    "\n",
+    "# the data should be the same as before matching at the locations where the shift\n",
+    "# was below 6 hours, and should be np.nan when shift was larger\n",
+    "should_be_nan = np.abs(random_shift) > 6\n",
+    "assert np.all(matched_random[~should_be_nan].values == random[~should_be_nan].values)\n",
+    "assert np.all(np.isnan(matched_random[should_be_nan].values))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`temporal_collocation` can also return the original index of the data that was matched as a separate column in the resulting DataFrame, if required, and can additionally also calculate the distance to the reference. The column names are \"index_other\" and \"distance_other\", respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                  0         1         2  \\\n",
+      "2020-01-01 00:00:00+00:00  1.201342 -0.800769  0.401427   \n",
+      "2020-01-02 00:00:00+00:00 -1.069162 -0.881217  0.778702   \n",
+      "2020-01-03 00:00:00+00:00 -0.139476  0.533678  0.563714   \n",
+      "2020-01-04 00:00:00+00:00 -0.697052 -2.088295  0.944217   \n",
+      "2020-01-05 00:00:00+00:00  0.077201 -0.079829 -0.236811   \n",
+      "...                             ...       ...       ...   \n",
+      "2020-12-27 00:00:00+00:00 -0.888301 -0.851369 -1.850475   \n",
+      "2020-12-28 00:00:00+00:00 -0.604062  0.294393 -0.566648   \n",
+      "2020-12-29 00:00:00+00:00 -0.122994 -0.372023 -0.619184   \n",
+      "2020-12-30 00:00:00+00:00 -1.486709  0.853604 -0.373724   \n",
+      "2020-12-31 00:00:00+00:00 -2.053052 -0.833403  0.547443   \n",
+      "\n",
+      "                                        index_other distance_other  \n",
+      "2020-01-01 00:00:00+00:00 2020-01-01 03:00:00+00:00       03:00:00  \n",
+      "2020-01-02 00:00:00+00:00 2020-01-02 03:00:00+00:00       03:00:00  \n",
+      "2020-01-03 00:00:00+00:00 2020-01-03 03:00:00+00:00       03:00:00  \n",
+      "2020-01-04 00:00:00+00:00 2020-01-04 03:00:00+00:00       03:00:00  \n",
+      "2020-01-05 00:00:00+00:00 2020-01-05 03:00:00+00:00       03:00:00  \n",
+      "...                                             ...            ...  \n",
+      "2020-12-27 00:00:00+00:00 2020-12-27 03:00:00+00:00       03:00:00  \n",
+      "2020-12-28 00:00:00+00:00 2020-12-28 03:00:00+00:00       03:00:00  \n",
+      "2020-12-29 00:00:00+00:00 2020-12-29 03:00:00+00:00       03:00:00  \n",
+      "2020-12-30 00:00:00+00:00 2020-12-30 03:00:00+00:00       03:00:00  \n",
+      "2020-12-31 00:00:00+00:00 2020-12-31 03:00:00+00:00       03:00:00  \n",
+      "\n",
+      "[366 rows x 5 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# also return original index and distance\n",
+    "matched_shifted = temporal_collocation(ref, shifted, window, return_index=True, return_distance=True)\n",
+    "print(matched_shifted)\n",
+    "\n",
+    "# the index should be the same as unmatched, and the distance should be 3  hours\n",
+    "assert np.all(matched_shifted[\"index_other\"].values == shifted.index.values)\n",
+    "assert np.all(matched_shifted[\"distance_other\"] == pd.Timedelta(hours=3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Flags\n",
+    "\n",
+    "Satellite data often contains flags indicating quality issues with the data. With `temporal_collocation` it is possible to use this information. Flags can either be provided as array (of the same length as the input DataFrame), or the name of a column in the DataFrame to be used as flag can be provided as string. Any non-zero flag is interpreted as indicating invalid data. By default this will not be used, but when passing ``use_invalid=True``, the invalid values will be used in case no valid match was found.\n",
+    "\n",
+    "For the following example, we reuse the input data shifted by 3 hours, but we will now assume that the first 3 observations had quality issues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ True,  True,  True, False, False, False, False, False, False,\n",
+       "       False])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# flag the first 3 observations as invalid\n",
+    "flag = np.zeros(len(ref), dtype=np.bool)\n",
+    "flag[0:3] = True\n",
+    "flag[0:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                  0         1         2\n",
+      "2020-01-01 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-01-02 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-01-03 00:00:00+00:00       NaN       NaN       NaN\n",
+      "2020-01-04 00:00:00+00:00 -0.697052 -2.088295  0.944217\n",
+      "2020-01-05 00:00:00+00:00  0.077201 -0.079829 -0.236811\n",
+      "...                             ...       ...       ...\n",
+      "2020-12-27 00:00:00+00:00 -0.888301 -0.851369 -1.850475\n",
+      "2020-12-28 00:00:00+00:00 -0.604062  0.294393 -0.566648\n",
+      "2020-12-29 00:00:00+00:00 -0.122994 -0.372023 -0.619184\n",
+      "2020-12-30 00:00:00+00:00 -1.486709  0.853604 -0.373724\n",
+      "2020-12-31 00:00:00+00:00 -2.053052 -0.833403  0.547443\n",
+      "\n",
+      "[366 rows x 3 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "matched_flagged = temporal_collocation(ref, shifted, window, flag=flag)\n",
+    "print(matched_flagged)\n",
+    "\n",
+    "# the first 3 values should be NaN, otherwise the result should be the same as matched_shifted\n",
+    "assert np.all(np.isnan(matched_flagged.values[0:3, :]))\n",
+    "assert np.all(matched_flagged.values[3:, :] == matched_shifted.values[3:, 0:3])  # excluding additonal columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                  0         1         2 my_flag\n",
+      "2020-01-01 00:00:00+00:00       NaN       NaN       NaN     NaN\n",
+      "2020-01-02 00:00:00+00:00       NaN       NaN       NaN     NaN\n",
+      "2020-01-03 00:00:00+00:00       NaN       NaN       NaN     NaN\n",
+      "2020-01-04 00:00:00+00:00 -0.697052 -2.088295  0.944217   False\n",
+      "2020-01-05 00:00:00+00:00  0.077201 -0.079829 -0.236811   False\n",
+      "...                             ...       ...       ...     ...\n",
+      "2020-12-27 00:00:00+00:00 -0.888301 -0.851369 -1.850475   False\n",
+      "2020-12-28 00:00:00+00:00 -0.604062  0.294393 -0.566648   False\n",
+      "2020-12-29 00:00:00+00:00 -0.122994 -0.372023 -0.619184   False\n",
+      "2020-12-30 00:00:00+00:00 -1.486709  0.853604 -0.373724   False\n",
+      "2020-12-31 00:00:00+00:00 -2.053052 -0.833403  0.547443   False\n",
+      "\n",
+      "[366 rows x 4 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This also works when the flag is already in the input frame, but note that\n",
+    "# in the output frame the nonzero flag values are replaced by NaN\n",
+    "flagged = shifted.assign(my_flag=flag)\n",
+    "matched_flagged = temporal_collocation(ref, flagged, window, flag=\"my_flag\")\n",
+    "print(matched_flagged)\n",
+    "\n",
+    "# the first 3 values should be NaN, otherwise the result should be the same as matched_shifted\n",
+    "assert np.all(np.isnan(matched_flagged.iloc[0:3, 0:3].values))\n",
+    "assert np.all(matched_flagged.iloc[3:, 0:3].values == matched_shifted.values[3:, 0:3])  # excluding additonal columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Handling of timezones\n",
+    "\n",
+    "`temporal_collocation` can also handle timezones. For this example, we use as the reference index from above, but shifted by 8 hours (to 8 am each day), and set it to UTC. The other DataFrame index is in Pacific time and remains at midnight. Since Pacific time is at -8 compared to UTC, they both refer to the same times (at least in winter, without DST).\n",
+    "\n",
+    "\n",
+    "Note that if no timezone information was given in the reference, it is assumed to be in UTC, and the resulting DataFrame will also be in UTC. When ``return_index=True``, the index of the input frame that is returned has been converted to the same time zone as the reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2020-01-01 08:00:00+00:00', '2020-01-02 08:00:00+00:00',\n",
+       "               '2020-01-03 08:00:00+00:00', '2020-01-04 08:00:00+00:00',\n",
+       "               '2020-01-05 08:00:00+00:00', '2020-01-06 08:00:00+00:00',\n",
+       "               '2020-01-07 08:00:00+00:00', '2020-01-08 08:00:00+00:00',\n",
+       "               '2020-01-09 08:00:00+00:00', '2020-01-10 08:00:00+00:00',\n",
+       "               ...\n",
+       "               '2020-12-22 08:00:00+00:00', '2020-12-23 08:00:00+00:00',\n",
+       "               '2020-12-24 08:00:00+00:00', '2020-12-25 08:00:00+00:00',\n",
+       "               '2020-12-26 08:00:00+00:00', '2020-12-27 08:00:00+00:00',\n",
+       "               '2020-12-28 08:00:00+00:00', '2020-12-29 08:00:00+00:00',\n",
+       "               '2020-12-30 08:00:00+00:00', '2020-12-31 08:00:00+00:00'],\n",
+       "              dtype='datetime64[ns, UTC]', length=366, freq='D')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# shift by +8 hours\n",
+    "utc_shifted = ref.copy().tz_localize(\"UTC\") + pd.Timedelta(hours=8)\n",
+    "utc_shifted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2020-01-01 00:00:00-08:00', '2020-01-02 00:00:00-08:00',\n",
+       "               '2020-01-03 00:00:00-08:00', '2020-01-04 00:00:00-08:00',\n",
+       "               '2020-01-05 00:00:00-08:00', '2020-01-06 00:00:00-08:00',\n",
+       "               '2020-01-07 00:00:00-08:00', '2020-01-08 00:00:00-08:00',\n",
+       "               '2020-01-09 00:00:00-08:00', '2020-01-10 00:00:00-08:00',\n",
+       "               ...\n",
+       "               '2020-12-22 00:00:00-08:00', '2020-12-23 00:00:00-08:00',\n",
+       "               '2020-12-24 00:00:00-08:00', '2020-12-25 00:00:00-08:00',\n",
+       "               '2020-12-26 00:00:00-08:00', '2020-12-27 00:00:00-08:00',\n",
+       "               '2020-12-28 00:00:00-08:00', '2020-12-29 00:00:00-08:00',\n",
+       "               '2020-12-30 00:00:00-08:00', '2020-12-31 00:00:00-08:00'],\n",
+       "              dtype='datetime64[ns, US/Pacific]', length=366, freq='D')"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# in pacific time it's now midnight\n",
+    "pacific_time = ref.copy().tz_localize(\"US/Pacific\")\n",
+    "pacific = pd.DataFrame(values, index=pacific_time)\n",
+    "\n",
+    "pacific_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TimedeltaIndex(['00:00:00', '00:00:00', '00:00:00', '00:00:00', '00:00:00',\n",
+       "                '00:00:00', '00:00:00', '00:00:00', '00:00:00', '00:00:00',\n",
+       "                ...\n",
+       "                '00:00:00', '00:00:00', '00:00:00', '00:00:00', '00:00:00',\n",
+       "                '00:00:00', '00:00:00', '00:00:00', '00:00:00', '00:00:00'],\n",
+       "               dtype='timedelta64[ns]', length=366, freq=None)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# but when converting the timezones to utc both, there's no time difference\n",
+    "pacific_time.tz_convert(\"UTC\") - utc_shifted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                  0         1         2  \\\n",
+      "2020-01-01 08:00:00+00:00  1.201342 -0.800769  0.401427   \n",
+      "2020-01-02 08:00:00+00:00 -1.069162 -0.881217  0.778702   \n",
+      "2020-01-03 08:00:00+00:00 -0.139476  0.533678  0.563714   \n",
+      "2020-01-04 08:00:00+00:00 -0.697052 -2.088295  0.944217   \n",
+      "2020-01-05 08:00:00+00:00  0.077201 -0.079829 -0.236811   \n",
+      "...                             ...       ...       ...   \n",
+      "2020-12-27 08:00:00+00:00 -0.888301 -0.851369 -1.850475   \n",
+      "2020-12-28 08:00:00+00:00 -0.604062  0.294393 -0.566648   \n",
+      "2020-12-29 08:00:00+00:00 -0.122994 -0.372023 -0.619184   \n",
+      "2020-12-30 08:00:00+00:00 -1.486709  0.853604 -0.373724   \n",
+      "2020-12-31 08:00:00+00:00 -2.053052 -0.833403  0.547443   \n",
+      "\n",
+      "                                        index_other  \n",
+      "2020-01-01 08:00:00+00:00 2020-01-01 08:00:00+00:00  \n",
+      "2020-01-02 08:00:00+00:00 2020-01-02 08:00:00+00:00  \n",
+      "2020-01-03 08:00:00+00:00 2020-01-03 08:00:00+00:00  \n",
+      "2020-01-04 08:00:00+00:00 2020-01-04 08:00:00+00:00  \n",
+      "2020-01-05 08:00:00+00:00 2020-01-05 08:00:00+00:00  \n",
+      "...                                             ...  \n",
+      "2020-12-27 08:00:00+00:00 2020-12-27 08:00:00+00:00  \n",
+      "2020-12-28 08:00:00+00:00 2020-12-28 08:00:00+00:00  \n",
+      "2020-12-29 08:00:00+00:00 2020-12-29 08:00:00+00:00  \n",
+      "2020-12-30 08:00:00+00:00 2020-12-30 08:00:00+00:00  \n",
+      "2020-12-31 08:00:00+00:00 2020-12-31 08:00:00+00:00  \n",
+      "\n",
+      "[366 rows x 4 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "matched = temporal_collocation(utc_shifted, pacific, window, return_index=True)\n",
+    "print(matched)\n",
+    "\n",
+    "# the first 50 (winter) time indices should be the same, and since all are within\n",
+    "# the 6 hour window, there should be no NaNs\n",
+    "assert np.all(matched.index[0:50] == matched[\"index_other\"][0:50])\n",
+    "assert not np.any(np.isnan(matched.iloc[:, 0:3]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:pytesmo]",
+   "language": "python",
+   "name": "conda-env-pytesmo-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/environment.yml
+++ b/environment.yml
@@ -26,5 +26,6 @@ dependencies:
     - ismn
     - repurpose
     - pytest
+    - pytest-cov
     - more_itertools
     - cadati

--- a/tests/test_temporal_matching.py
+++ b/tests/test_temporal_matching.py
@@ -303,8 +303,9 @@ def test_collocation_window(test_data, key):
 def test_collocation_input(test_data, key):
     ref_frame, test_frame, expected_nan = setup_data(test_data, key)
 
+    no_timezone = pd.date_range('1970', '2020', freq='D')
     # test with series and index:
-    for ref in [ref_frame[0], ref_frame.index]:
+    for ref in [ref_frame[0], ref_frame.index, no_timezone]:
         res = tmatching.temporal_collocation(
             ref, test_frame, pd.Timedelta(6, "H")
         )


### PR DESCRIPTION
This contains a new implementation of temporal matching/collocation, as discussed in #176.

It uses ``pd.reindex`` for matching with nearest neighbours, as was done in `smecv`. I added a method keyword, so different collocation/interpolation methods can be implemented in the future, if necessary.