### PR TITLE
Cdf matching issue 309

### DIFF
--- a/src/pytesmo/scaling.py
+++ b/src/pytesmo/scaling.py
@@ -351,7 +351,6 @@ def cdf_match(src, ref,
         Maximum allowed value, output data is capped at this value
     nbins: int, optional
         Number of bins to use for estimation of the CDF
-        The default is True.
     minobs : int
         Minimum desired number of observations in a bin.
     ** kwargs: dict
@@ -381,6 +380,7 @@ def cdf_match(src, ref,
 
 def cdf_beta_match(src, ref,
                    minobs=20,
+                   lin_edge_scaling=True,
                    nbins=100,
                    **kwargs):
     """
@@ -417,6 +417,16 @@ def cdf_beta_match(src, ref,
 
     if not minobs is None:    
         percentiles = utils.resize_percentiles(src, percentiles, minobs)
+    
+    # match the two arrays
+    if len(src) != len(ref):
+        max_obs = max(len(src), len(ref))
+        d_perc = np.arange(max_obs, dtype='float') / (max_obs-1)*100
+
+        if len(src) < len(ref):
+            src = utils.ml_percentile(src, d_perc)
+        else:
+            ref = utils.ml_percentile(ref, d_perc)
         
     # calculate percentiles using matlab method
     perc_src = utils.ml_percentile(src, percentiles)
@@ -429,7 +439,7 @@ def cdf_beta_match(src, ref,
         perc_src = utils.unique_percentiles_beta(perc_src, percentiles=percentiles)
         
     return gen_cdf_match(src, perc_src, perc_ref,
-                         lin_edge_scaling=True,
+                         lin_edge_scaling=lin_edge_scaling,
                          ref=ref, 
                          **kwargs)
 

--- a/src/pytesmo/scaling.py
+++ b/src/pytesmo/scaling.py
@@ -246,7 +246,7 @@ def mean_std(src, ref, **kwargs):
     return ((src - np.mean(src)) /
             np.std(src)) * np.std(ref) + np.mean(ref)
 
-
+@utils.deprecated
 def lin_cdf_match(src, ref,
                   min_val=None, max_val=None,
                   percentiles=[0, 5, 10, 30, 50, 70, 90, 95, 100],
@@ -325,6 +325,7 @@ def lin_cdf_match_stored_params(src, perc_src, perc_ref,
                          min_val=min_val, max_val=max_val,
                          k=1, **kwargs)
 
+@utils.deprecated
 def cdf_match(src, ref,
               min_val=None, max_val=None,
               nbins=100,
@@ -361,7 +362,6 @@ def cdf_match(src, ref,
     CDF matched values: numpy.array
         dataset src with CDF as ref
     '''
-
     percentiles = np.linspace(0, 100, nbins)
     
     if not minobs is None:      

--- a/src/pytesmo/utils.py
+++ b/src/pytesmo/utils.py
@@ -145,12 +145,12 @@ def unique_percentiles_interpolate(perc_values,
         Unique percentile values generated through linear
         interpolation over removed duplicate percentile values
     """
-    uniq_ind = np.unique(perc_values, return_index=True)[1]
+    uniq_ind = np.sort(np.unique(perc_values, return_index=True)[1])
     if len(uniq_ind) == 1:
         uniq_ind = np.repeat(uniq_ind, 2)
     uniq_ind[-1] = len(percentiles) - 1
     uniq_perc_values = perc_values[uniq_ind]
-
+    # is part below really needed?
     inter = sc_int.InterpolatedUnivariateSpline(
         np.array(percentiles)[uniq_ind],
         uniq_perc_values,
@@ -273,3 +273,122 @@ def array_dropna(*arrs):
     if len(arrs_dropna) == 1: arrs_dropna = arrs_dropna[0]
 
     return tuple(arrs_dropna)
+
+def get_edge_percentiles(percentiles, n=1):
+    '''
+    Finds the percentile values used in the edge definition
+
+    Parameters
+    ----------
+    percentiles : np.array
+        percentile values for a timeseries
+    n : int, optional
+        Passed from scale_edges(). The default is 1.
+
+    Returns
+    -------
+    edge_perc : TYPE
+        DESCRIPTION.
+
+    '''
+    edge_perc = {}
+    edge_perc['inside_lo'] = percentiles[n]
+    edge_perc['outside_lo'] = percentiles[n-1]
+    edge_perc['inside_hi'] = percentiles[-1-n]
+    edge_perc['outside_hi'] = percentiles[-n]
+    
+    return edge_perc
+
+def derive_edge_parameters(src, ref, edge_src, edge_ref):
+    '''
+    Method to compute the slopes for the edge matching in CDF matching,
+    based on a linear scaling model.
+
+    Parameters
+    ----------
+    src : numpy.array
+        input dataset which will be scaled
+    ref : numpy.array
+        src will be scaled to this dataset
+    edge_src : list
+        list with low and high edges (in percentile values) of src
+    edge_ref : list
+        list with low and high edges (in percentile values) of ref
+
+    Returns
+    -------
+    slope_low : float
+        slope parameter to scale the lower edge.
+    slope_high : float
+        slope parameter to scale the higher edge.
+    '''
+    x_lo = src[src <= edge_src['inside_lo']] - edge_src['inside_lo']
+    y_lo = ref[ref <= edge_ref['inside_lo']] - edge_ref['inside_lo']
+    x_hi = src[src >= edge_src['inside_hi']] - edge_src['inside_hi']
+    y_hi = ref[ref >= edge_ref['inside_hi']] - edge_ref['inside_hi']
+    
+    def return_regress(x,y,
+                       where,
+                       edge_src=edge_src,
+                       edge_ref=edge_ref):
+        l = min(len(x),len(y))
+        x, y = x[:l], y[:l]
+        x, y = np.sort(x), np.sort(y)
+        slope, res, rank, s = np.linalg.lstsq(x.reshape(-1, 1), y, rcond=None)
+        if where == 'low':
+            intercept = edge_ref['inside_lo'] - slope[0]*edge_src['inside_lo']
+        elif where == 'high':
+            intercept = edge_ref['inside_hi'] - slope[0]*edge_src['inside_hi']
+        
+        return slope[0], intercept 
+    
+    parms_lo = return_regress(x_lo, y_lo, 'low')
+    parms_hi = return_regress(x_hi, y_hi, 'high')
+    
+    return parms_lo, parms_hi
+
+def scale_edges(scaled, src, ref, perc_src, perc_ref, n=1):
+    '''
+    Method to scale the edges of the src timeseries using a linear regression
+    method based on Moesinger et al. (2020).
+    The edges are defined as the values below the second (nth + 1) or above the
+    penultimate (X-1-nth) quantile in the src timeseries.
+
+    Parameters
+    ----------
+    scaled : numpy.array
+        scaled array where edge values should be replaced
+    src : numpy.array
+        input dataset which will be scaled.
+    ref : numpy.array
+        src will be scaled to this dataset
+    perc_src : numpy.array
+        percentiles of src
+    perc_ref : numpy.array
+        percentiles of reference data
+    n : int, optional
+        Edges are percentile values below the nth+1 percentile and above the
+        -1-nth percentile. The default is 1.
+
+    Returns
+    -------
+    scaled : numpy.array
+        Scaled timeseries with scaled edges
+    '''
+    # get edge percentile value
+    edge_src = get_edge_percentiles(perc_src, n=n)
+    edge_ref = get_edge_percentiles(perc_ref, n=n)
+    
+    # calculate scaling slope at edges
+    parms_lo, parms_hi = derive_edge_parameters(src=src,
+                        ref=ref, edge_src= edge_src, edge_ref=edge_ref)
+    
+    # find indexes of edge values in source data
+    ids_lo = np.where(src <= edge_src['inside_lo'])
+    ids_hi = np.where(src >= edge_src['inside_hi'])
+    
+    # correct the scaled data at the edges
+    scaled[ids_lo] = scaled[ids_lo]*parms_lo[0] + parms_lo[1]
+    scaled[ids_hi] = scaled[ids_hi]*parms_hi[0] + parms_hi[1]
+
+    return scaled

--- a/src/pytesmo/utils.py
+++ b/src/pytesmo/utils.py
@@ -313,8 +313,8 @@ def derive_edge_parameters(src, ref, perc_src, perc_ref):
                        where,
                        perc_src=perc_src,
                        perc_ref=perc_ref):
-        l = min(len(x),len(y))
-        x, y = x[:l], y[:l]
+        n = min(len(x),len(y))
+        x, y = x[:n], y[:n]
         x, y = np.sort(x), np.sort(y)
         slope, res, rank, s = np.linalg.lstsq(x.reshape(-1, 1), y, rcond=None)
         if where == 'low':

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -80,7 +80,30 @@ def test_scaling_method(method):
 
     o = getattr(scaling, method)(y, x)
     nptest.assert_almost_equal(x, o)
+    
+@pytest.mark.parametrize('method', scaling_methods)
+def test_scaling_kwargs(method):
+    """
+    Tests that kwargs are passed correctly for every scaling method
+    """
 
+    # two linear functions should be matched onto each other
+    n = 1000
+    x = np.arange(n)
+    y = np.arange(n) * 0.5
+    raised = False
+    
+    try:
+        kwargs = {'lin_edge_scaling':True,
+                  'minobs':20,
+                  'max_val':950,
+                  'min_val':50}
+        o = getattr(scaling, method)(y, x, **kwargs)
+    
+    except:
+        raised = True
+    
+    assert raised is False
 
 @pytest.mark.parametrize('method', scaling_methods)
 def test_scale(method):


### PR DESCRIPTION
This PR provides an update on the CDF scaling methods in `scaling.py` based on Moesinger et al. (2020). It includes:

- The function `cdf_beta_match`, allowing to scale the source to the reference timeseries using the CDF of the reference and the CDF of the source, fitted on a beta distribution function
- An improved methodology for the scaling of values below the second and above the penultimate percentiles
- An improved methodology to dynamically increase the size of percentile bins in case too few observations are found in a bin, avoiding issues with the overfitting of scaling parameters

The improvements have been made available for the `cdf_match` and `lin_cdf_match` functions as well, although all changes are optional to avoid issues with previous uses of Pytesmo.