### PR TITLE
Fix bug in indexing when interpolate leapday was set

### DIFF
--- a/src/pytesmo/time_series/anomaly.py
+++ b/src/pytesmo/time_series/anomaly.py
@@ -187,11 +187,6 @@ def calc_climatology(Ser,
     clim_ser = pd.Series(clim.values.flatten(),
                          index=clim.index.values)
 
-    if interpolate_leapday and not respect_leap_years:
-        clim_ser[60] = np.mean((clim_ser[59], clim_ser[61]))
-    elif interpolate_leapday and respect_leap_years:
-        clim_ser[366] = np.mean((clim_ser[365], clim_ser[1]))
-
     if wraparound:
         index_old = clim_ser.index.copy()
         left_mirror = clim_ser.iloc[-moving_avg_clim:]
@@ -211,5 +206,12 @@ def calc_climatology(Ser,
         clim_ser = moving_average(clim_ser, window_size=moving_avg_clim, fillna=fillna, min_obs=min_obs_clim)
 
     clim_ser = clim_ser.reindex(np.arange(366) + 1)
+
+    if interpolate_leapday and not respect_leap_years:
+        clim_ser[60] = np.mean((clim_ser[59], clim_ser[61]))
+    elif interpolate_leapday and respect_leap_years:
+        clim_ser[366] = np.mean((clim_ser[365], clim_ser[1]))
+
     clim_ser = clim_ser.fillna(fill)
+
     return clim_ser

--- a/tests/test_time_series/test_anomaly.py
+++ b/tests/test_time_series/test_anomaly.py
@@ -87,6 +87,12 @@ def test_climatology_always_366():
     clim = anomaly.calc_climatology(ts)
     assert clim.size == 366
 
+    # this should also be the case if interpolate_leapday is set
+    ts = pd.Series(np.sin(np.arange(10)), index=pd.date_range(
+        '2000-01-01', freq='D', periods=10))
+    clim = anomaly.calc_climatology(ts, interpolate_leapday=True)
+    assert clim.size == 366
+
 
 def test_climatology_always_366_fill():
     ts = pd.Series(np.sin(np.arange(366) / 366. * 2 * np.pi), index=pd.date_range(


### PR DESCRIPTION
If input data is less than 1 year then this failed because it tried to index
days that did not exist