### PR TITLE
Use assert_almost_equal in deprecated MSE test

### DIFF
--- a/tests/test_metrics_deprecated.py
+++ b/tests/test_metrics_deprecated.py
@@ -143,8 +143,8 @@ def test_mse(arange_testdata):
         mse_bias_pred = 2. ** 2
         mse_obs, _, mse_bias, _ = met.mse(x, y)
 
-        nptest.assert_equal(mse_obs, mse_pred)
-        nptest.assert_equal(mse_bias, mse_bias_pred)
+        nptest.assert_almost_equal(mse_obs, mse_pred)
+        nptest.assert_almost_equal(mse_bias, mse_bias_pred)
 
         # example 2, with outlier
         y[-1] = 51.


### PR DESCRIPTION
This failed for on a machine (osx arm64) with

```
    def test_mse(arange_testdata):
        """
        Test for mse
        """
        with pytest.deprecated_call():
            # example 1
            x, y = arange_testdata

            mse_pred = 4.
            mse_bias_pred = 2. ** 2
            mse_obs, _, mse_bias, _ = met.mse(x, y)

>           nptest.assert_equal(mse_obs, mse_pred)
E           AssertionError:
E           Items are not equal:
E            ACTUAL: 4.0000000000000036
E            DESIRED: 4.0
```