### PR TITLE
Add adapter to combine multiple columns returned by read function

### DIFF
--- a/src/pytesmo/validation_framework/adapters.py
+++ b/src/pytesmo/validation_framework/adapters.py
@@ -36,6 +36,7 @@ import operator
 from pytesmo.time_series.anomaly import calc_anomaly
 from pytesmo.time_series.anomaly import calc_climatology
 from pandas import DataFrame
+import pandas as pd
 
 
 class BasicAdapter(object):
@@ -314,3 +315,51 @@ class AnomalyClimAdapter(BasicAdapter):
     def read(self, *args, **kwargs):
         data = super(AnomalyClimAdapter, self).read(*args, **kwargs)
         return self.calc_anom(data)
+
+
+class ColumnCombAdapter(BasicAdapter):
+    """
+    Takes the pandas DataFrame that the read_ts or read method of the instance
+    returns and applies a function to merge multiple columns into one.
+    E.g. when there are 2 Soil Moisture parameters in a dataset that should be
+    averaged on reading. Will add one additional column to the input data frame.
+    """
+
+    def __init__(self, cls, func, func_kwargs=None, columns=None, new_name='merged'):
+        """
+        Parameters
+        ----------
+        cls : class instance
+            Must have a read_ts or read method returning a pandas.DataFrame
+        func: Callable
+            Will be applied to dataframe columns using pd.DataFrame.apply(..., axis=1)
+            additional kwargs for this must be given in func_kwargs,
+            e.g. pd.DataFrame.mean
+        func_kwargs : dict, optional (default: None)
+            kwargs that are passed to method
+        columns: list, optional
+            columns in the dataset that are combined.
+        new_name: str, optional (default: merged)
+            Name that the merged column will have in the returned data frame.
+        """
+
+        super(ColumnCombAdapter, self).__init__(cls)
+        self.func = func
+        self.func_kwargs = func_kwargs if func_kwargs is not None else {}
+        self.func_kwargs['axis'] = 1
+        self.columns = columns
+        self.new_name = new_name
+
+    def apply(self, data: pd.DataFrame) -> pd.DataFrame:
+        columns = data.columns if self.columns is None else self.columns
+        new_col = data[columns].apply(self.func, **self.func_kwargs)
+        data[self.new_name] = new_col
+        return data
+
+    def read_ts(self, *args, **kwargs) -> pd.DataFrame:
+        data = super(ColumnCombAdapter, self).read_ts(*args, **kwargs)
+        return self.apply(data)
+
+    def read(self, *args, **kwargs) -> pd.DataFrame:
+        data = super(ColumnCombAdapter, self).read(*args, **kwargs)
+        return self.apply(data)

--- a/src/pytesmo/validation_framework/adapters.py
+++ b/src/pytesmo/validation_framework/adapters.py
@@ -316,7 +316,7 @@ class AnomalyClimAdapter(BasicAdapter):
         return self.calc_anom(data)
 
 
-class ColumnCombAdapter(BasicAdapter):
+class ColumnCombineAdapter(BasicAdapter):
     """
     Takes the pandas DataFrame that the read_ts or read method of the instance
     returns and applies a function to merge multiple columns into one.
@@ -336,13 +336,14 @@ class ColumnCombAdapter(BasicAdapter):
             e.g. pd.DataFrame.mean
         func_kwargs : dict, optional (default: None)
             kwargs that are passed to method
-        columns: list, optional
-            columns in the dataset that are combined.
+        columns: list, optional (default: None)
+            Columns in the dataset that are combined. If None are selected
+            all columns are used.
         new_name: str, optional (default: merged)
             Name that the merged column will have in the returned data frame.
         """
 
-        super(ColumnCombAdapter, self).__init__(cls)
+        super(ColumnCombineAdapter, self).__init__(cls)
         self.func = func
         self.func_kwargs = func_kwargs if func_kwargs is not None else {}
         self.func_kwargs['axis'] = 1
@@ -356,9 +357,8 @@ class ColumnCombAdapter(BasicAdapter):
         return data
 
     def read_ts(self, *args, **kwargs) -> DataFrame:
-        data = super(ColumnCombAdapter, self).read_ts(*args, **kwargs)
+        data = super(ColumnCombineAdapter, self).read_ts(*args, **kwargs)
         return self.apply(data)
 
     def read(self, *args, **kwargs) -> DataFrame:
-        data = super(ColumnCombAdapter, self).read(*args, **kwargs)
-        return self.apply(data)
+        return self.read_ts(*args, **kwargs)

--- a/src/pytesmo/validation_framework/adapters.py
+++ b/src/pytesmo/validation_framework/adapters.py
@@ -36,7 +36,6 @@ import operator
 from pytesmo.time_series.anomaly import calc_anomaly
 from pytesmo.time_series.anomaly import calc_climatology
 from pandas import DataFrame
-import pandas as pd
 
 
 class BasicAdapter(object):
@@ -350,16 +349,16 @@ class ColumnCombAdapter(BasicAdapter):
         self.columns = columns
         self.new_name = new_name
 
-    def apply(self, data: pd.DataFrame) -> pd.DataFrame:
+    def apply(self, data: DataFrame) -> DataFrame:
         columns = data.columns if self.columns is None else self.columns
         new_col = data[columns].apply(self.func, **self.func_kwargs)
         data[self.new_name] = new_col
         return data
 
-    def read_ts(self, *args, **kwargs) -> pd.DataFrame:
+    def read_ts(self, *args, **kwargs) -> DataFrame:
         data = super(ColumnCombAdapter, self).read_ts(*args, **kwargs)
         return self.apply(data)
 
-    def read(self, *args, **kwargs) -> pd.DataFrame:
+    def read(self, *args, **kwargs) -> DataFrame:
         data = super(ColumnCombAdapter, self).read(*args, **kwargs)
         return self.apply(data)

--- a/tests/test_validation_framework/test_adapters.py
+++ b/tests/test_validation_framework/test_adapters.py
@@ -41,6 +41,7 @@ import warnings
 from pytesmo.validation_framework.adapters import (
     MaskingAdapter,
     AdvancedMaskingAdapter,
+    ColumnCombAdapter
 )
 from pytesmo.validation_framework.adapters import SelfMaskingAdapter
 from pytesmo.validation_framework.adapters import AnomalyAdapter
@@ -264,3 +265,17 @@ def test_timezone_removal():
 
     reader_clim = AnomalyClimAdapter(tz_reader, columns=["data"])
     assert reader_clim.read_ts(0) is not None
+
+
+def test_column_comb_adapter():
+    ds = TestDataset("", n=20)
+    orig = ds.read()
+    ds_adapted = ColumnCombAdapter(ds, func=pd.DataFrame.mean, columns=["x", "y"],
+                                func_kwargs={'skipna': True}, new_name='xy_mean')
+    ds_mean1 = ds_adapted.read_ts()
+    ds_mean2 = ds_adapted.read()
+
+    for ds_mean in [ds_mean1, ds_mean2]:
+        nptest.assert_almost_equal(ds_mean["x"].values, orig["x"].values)
+        nptest.assert_almost_equal(ds_mean["y"].values, orig["y"].values)
+        nptest.assert_almost_equal(ds_mean["xy_mean"].values, (ds_mean["x"] + ds_mean["y"]) / 2.)

--- a/tests/test_validation_framework/test_adapters.py
+++ b/tests/test_validation_framework/test_adapters.py
@@ -41,7 +41,7 @@ import warnings
 from pytesmo.validation_framework.adapters import (
     MaskingAdapter,
     AdvancedMaskingAdapter,
-    ColumnCombAdapter
+    ColumnCombineAdapter
 )
 from pytesmo.validation_framework.adapters import SelfMaskingAdapter
 from pytesmo.validation_framework.adapters import AnomalyAdapter
@@ -270,12 +270,12 @@ def test_timezone_removal():
 def test_column_comb_adapter():
     ds = TestDataset("", n=20)
     orig = ds.read()
-    ds_adapted = ColumnCombAdapter(ds, func=pd.DataFrame.mean, columns=["x", "y"],
-                                func_kwargs={'skipna': True}, new_name='xy_mean')
+    ds_adapted = ColumnCombineAdapter(ds, func=pd.DataFrame.mean, columns=["x", "y"],
+                                      func_kwargs={'skipna': True}, new_name='xy_mean')
     ds_mean1 = ds_adapted.read_ts()
     ds_mean2 = ds_adapted.read()
 
     for ds_mean in [ds_mean1, ds_mean2]:
-        nptest.assert_almost_equal(ds_mean["x"].values, orig["x"].values)
-        nptest.assert_almost_equal(ds_mean["y"].values, orig["y"].values)
-        nptest.assert_almost_equal(ds_mean["xy_mean"].values, (ds_mean["x"] + ds_mean["y"]) / 2.)
+        nptest.assert_equal(ds_mean["x"].values, orig["x"].values)
+        nptest.assert_equal(ds_mean["y"].values, orig["y"].values)
+        nptest.assert_equal(ds_mean["xy_mean"].values, (ds_mean["x"] + ds_mean["y"]) / 2.)


### PR DESCRIPTION
Recently I had the case where we had multiple layers of RZSM in a dataset and wanted to compare it to a model which had one (much wider) layer as the reference. So I wrote this adapter to merge columns upon passing them into the validation framework. What do you think @s-scherrer @pstradio does this make sense here?