### PR TITLE
Fix rollmetric

### DIFF
--- a/src/pytesmo/metrics/_fast_pairwise.pyx
+++ b/src/pytesmo/metrics/_fast_pairwise.pyx
@@ -338,10 +338,10 @@ cpdef _pearsonr_from_moments(floating varx, floating vary, floating cov, int n):
 # This implementation is much faster than the old version with numba:
 # old: 76.7 ms ± 1.62 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
 # new: 117 µs ± 836 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
-cpdef rolling_pr_rmsd(floating [:] timestamps,
+cpdef rolling_pr_rmsd(double [:] timestamps,
                       floating [:] x,
                       floating [:] y,
-                      floating window_size,
+                      double window_size,
                       int center,
                       int min_periods):
     """
@@ -353,7 +353,7 @@ cpdef rolling_pr_rmsd(floating [:] timestamps,
         Time stamps as julian dates.
     data : numpy.ndarray
         Time series data in 2d array.
-    window_size : float
+    window_size : float64
         Window size in fraction of days.
     center : bool
         Set window at the center and include window_size in both directions.

--- a/src/pytesmo/validation_framework/metric_calculators.py
+++ b/src/pytesmo/validation_framework/metric_calculators.py
@@ -1259,7 +1259,7 @@ class RollingMetrics(MetadataMetrics):
         window_size_jd = pd.Timedelta(
             window_size).to_numpy()/np.timedelta64(1, 'D')
         pr_arr, rmsd_arr = metrics.rolling_pr_rmsd(
-            timestamps,
+            timestamps.astype('float32'),
             xy[:, 0],
             xy[:, 1],
             window_size_jd,

--- a/src/pytesmo/validation_framework/metric_calculators.py
+++ b/src/pytesmo/validation_framework/metric_calculators.py
@@ -1259,9 +1259,9 @@ class RollingMetrics(MetadataMetrics):
         window_size_jd = pd.Timedelta(
             window_size).to_numpy()/np.timedelta64(1, 'D')
         pr_arr, rmsd_arr = metrics.rolling_pr_rmsd(
-            timestamps.astype('float32'),
-            xy[:, 0],
-            xy[:, 1],
+            timestamps.astype('float64'),
+            xy[:, 0].astype('float64'),
+            xy[:, 1].astype('float64'),
             window_size_jd,
             center,
             min_periods

--- a/src/pytesmo/validation_framework/metric_calculators.py
+++ b/src/pytesmo/validation_framework/metric_calculators.py
@@ -1259,9 +1259,9 @@ class RollingMetrics(MetadataMetrics):
         window_size_jd = pd.Timedelta(
             window_size).to_numpy()/np.timedelta64(1, 'D')
         pr_arr, rmsd_arr = metrics.rolling_pr_rmsd(
-            timestamps.astype('float64'),
-            xy[:, 0].astype('float64'),
-            xy[:, 1].astype('float64'),
+            timestamps,
+            xy[:, 0],
+            xy[:, 1],
             window_size_jd,
             center,
             min_periods


### PR DESCRIPTION
Some readers return data not as float64 (but as float32) in that case the rollmetrics may not get data in the expected format. This forces float64 to fix this.