### PR TITLE
Calc debugging

### DIFF
--- a/src/pytesmo/validation_framework/metric_calculators.py
+++ b/src/pytesmo/validation_framework/metric_calculators.py
@@ -1717,16 +1717,17 @@ class TripleCollocationMetrics(MetadataMetrics, PairwiseMetricsMixin):
         result = super().calc_metrics(data, gpi_info)
         n_obs = len(data)
         result["n_obs"][0] = n_obs
-        if n_obs < self.min_obs:
-            warnings.warn(
-                "Not enough observations to calculate metrics.", UserWarning
-            )
-            return result
 
         # get the remaining metrics template for this specific combination
         othernames = list(data.columns)
         othernames.remove(self.refname)
         result.update(self._get_metric_template(self.refname, othernames))
+
+        if n_obs < self.min_obs:
+            warnings.warn(
+                "Not enough observations to calculate metrics.", UserWarning
+            )
+            return result
 
         # calculate triple collocation metrics
         ds_names = (self.refname, *othernames)

--- a/src/pytesmo/validation_framework/metric_calculators.py
+++ b/src/pytesmo/validation_framework/metric_calculators.py
@@ -1738,10 +1738,16 @@ class TripleCollocationMetrics(MetadataMetrics, PairwiseMetricsMixin):
                 for j, metric in enumerate(["snr", "err_std", "beta"]):
                     result[(metric, name)][0] = res[j][i]
         else:
-            res = tcol_metrics_with_bootstrapped_ci(*arrays)
-            for i, name in enumerate(ds_names):
-                for j, metric in enumerate(["snr", "err_std", "beta"]):
-                    result[(metric, name)][0] = res[j][0][i]
-                    result[(metric + "_ci_lower", name)][0] = res[j][1][i]
-                    result[(metric + "_ci_upper", name)][0] = res[j][2][i]
+            try:
+                # handle failing bootstrapping because e.g.
+                # too small sample size
+                res = tcol_metrics_with_bootstrapped_ci(*arrays)
+                for i, name in enumerate(ds_names):
+                    for j, metric in enumerate(["snr", "err_std", "beta"]):
+                        result[(metric, name)][0] = res[j][0][i]
+                        result[(metric + "_ci_lower", name)][0] = res[j][1][i]
+                        result[(metric + "_ci_upper", name)][0] = res[j][2][i]
+            except ValueError:
+                # if the calculation fails, the template results (np.nan) are used
+                pass
         return result

--- a/src/pytesmo/validation_framework/validation.py
+++ b/src/pytesmo/validation_framework/validation.py
@@ -265,7 +265,14 @@ class Validation(object):
             for field_name in results[key][0].keys():
                 entries = []
                 for result in results[key]:
-                    entries.append(result[field_name][0])
+                    try:
+                        entries.append(result[field_name][0])
+                    except KeyError:
+                        # indicating a metric result was not produced
+                        warnings.warn(
+                            f"No TCA results for gpi: {result['gpi']}"
+                        )
+                        entries.append(np.nan)
                 compact_results[key][field_name] = np.array(
                     entries, dtype=results[key][0][field_name].dtype
                 )

--- a/src/pytesmo/validation_framework/validation.py
+++ b/src/pytesmo/validation_framework/validation.py
@@ -267,10 +267,11 @@ class Validation(object):
                 for result in results[key]:
                     try:
                         entries.append(result[field_name][0])
-                    except KeyError:
+                    except KeyError as e:
                         # indicating a metric result was not produced
                         warnings.warn(
-                            f"No TCA results for gpi: {result['gpi']}"
+                            f"No TCA results for gpi: {result['gpi']}. Error "
+                            f"message: {e}"
                         )
                         entries.append(np.nan)
                 compact_results[key][field_name] = np.array(

--- a/src/pytesmo/validation_framework/validation.py
+++ b/src/pytesmo/validation_framework/validation.py
@@ -265,15 +265,7 @@ class Validation(object):
             for field_name in results[key][0].keys():
                 entries = []
                 for result in results[key]:
-                    try:
-                        entries.append(result[field_name][0])
-                    except KeyError as e:
-                        # indicating a metric result was not produced
-                        warnings.warn(
-                            f"No TCA results for gpi: {result['gpi']}. Error "
-                            f"message: {e}"
-                        )
-                        entries.append(np.nan)
+                    entries.append(result[field_name][0])
                 compact_results[key][field_name] = np.array(
                     entries, dtype=results[key][0][field_name].dtype
                 )


### PR DESCRIPTION
Handles exceptions in `validation_framework.validation.calc()` when a metric is not computed (e.g. TC errors) and not written to the results dictionary.  