### PR TITLE
Added timestamp adapter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Unreleased
 - ipynb files from docs/examples are now also used as (optional) tests (PR `#263 <https://github.com/TUW-GEO/pytesmo/pull/263>`_)
 - ``yapf`` for code formatting (see developers guide) (Fix #248, PR `#263 <https://github.com/TUW-GEO/pytesmo/pull/263>`_)
 - validation framework option to force dataset combinations that include reference dataset updated (PR `#265 <https://github.com/TUW-GEO/pytesmo/pull/265>`_)
+- Added `TimestampAdapter` to the validation framework to deal with datasets that have different date/time specification fields (PR `#268 <https://github.com/TUW-GEO/pytesmo/pull/268>`_)
 
 Version 0.13.4, 2022-01-12
 ==========================

--- a/src/pytesmo/validation_framework/adapters.py
+++ b/src/pytesmo/validation_framework/adapters.py
@@ -507,8 +507,10 @@ class ColumnCombineAdapter(BasicAdapter):
 
 class TimestampAdapter(BasicAdapter):
     """
-    Class that adapts the (midnight) timestamp read with the generic read function
-    to the exact overpass time using the specified offset value
+    Class that adapts the "generic" (e.g. midnight or averaged) timestamp*
+    read with the generic read function to the exact overpass time using
+    the specified offset value. This is useful in aggregated products such as
+    L3 data sets
 
     Parameters
     ----------
@@ -536,7 +538,7 @@ class TimestampAdapter(BasicAdapter):
             self,
             cls: object,
             time_offset_field: str,
-            time_units: str,
+            time_units: str = "s",
             **kwargs
     ):
         super().__init__(cls, **kwargs)

--- a/src/pytesmo/validation_framework/adapters.py
+++ b/src/pytesmo/validation_framework/adapters.py
@@ -24,8 +24,6 @@
 # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
 """
 Module containing adapters that can be used together with the validation
 framework.
@@ -90,11 +88,9 @@ class BasicAdapter:
             setattr(self, read_name, self._adapt_custom)
 
     def __get_dataframe(self, data):
-        if (
-                (not isinstance(data, DataFrame))
-                and (hasattr(data, self.data_property_name))
-                and (isinstance(getattr(data, self.data_property_name), DataFrame))
-        ):
+        if ((not isinstance(data, DataFrame)) and
+            (hasattr(data, self.data_property_name)) and
+            (isinstance(getattr(data, self.data_property_name), DataFrame))):
             data = getattr(data, self.data_property_name)
         return data
 
@@ -102,15 +98,14 @@ class BasicAdapter:
         if hasattr(data.index, "tz") and (data.index.tz is not None):
             warnings.warn(
                 f"Dropping timezone information ({data.index.tz})"
-                f" for data from reader {self.cls.__class__.__name__}"
-            )
+                f" for data from reader {self.cls.__class__.__name__}")
             data.index = data.index.tz_convert(None)
         return data
 
     def _adapt(self, df: DataFrame) -> DataFrame:
         # drop time zone info and extract df from ASCAT TS object
-        return self.__drop_tz_info(self.__get_dataframe(df)
-                                   if df is not None else DataFrame())
+        return self.__drop_tz_info(
+            self.__get_dataframe(df) if df is not None else DataFrame())
 
     def _adapt_custom(self, *args, **kwargs):
         # modifies data from whatever function was set as `read_name`.
@@ -134,10 +129,8 @@ class BasicAdapter:
             return self.cls.grid
 
 
-@deprecated(
-    "`MaskingAdapter` is deprecated, use `SelfMaskingAdapter` "
-    "or `AdvancedMaskingAdapter` instead."
-)
+@deprecated("`MaskingAdapter` is deprecated, use `SelfMaskingAdapter` "
+            "or `AdvancedMaskingAdapter` instead.")
 class MaskingAdapter(BasicAdapter):
     """
     Transform the given class to return a boolean dataset given the operator
@@ -371,8 +364,7 @@ class AnomalyAdapter(BasicAdapter):
             ite = self.columns
         for column in ite:
             data[column] = calc_anomaly(
-                data[column], window_size=self.window_size
-            )
+                data[column], window_size=self.window_size)
         return data
 
 
@@ -445,13 +437,13 @@ class ColumnCombineAdapter(BasicAdapter):
     """
 
     def __init__(
-            self,
-            cls,
-            func,
-            func_kwargs=None,
-            columns=None,
-            new_name="merged",
-            **kwargs,
+        self,
+        cls,
+        func,
+        func_kwargs=None,
+        columns=None,
+        new_name="merged",
+        **kwargs,
     ):
         """
         Parameters
@@ -534,13 +526,11 @@ class TimestampAdapter(BasicAdapter):
         will be adapted.
     """
 
-    def __init__(
-            self,
-            cls: object,
-            time_offset_field: str,
-            time_units: str = "s",
-            **kwargs
-    ):
+    def __init__(self,
+                 cls: object,
+                 time_offset_field: str,
+                 time_units: str = "s",
+                 **kwargs):
         super().__init__(cls, **kwargs)
 
         self.time_offset_field = time_offset_field
@@ -555,10 +545,8 @@ class TimestampAdapter(BasicAdapter):
 
         # Add time offset
         offset = data[self.time_offset_field].map(
-            lambda x:
-            np.timedelta64(int(x), self.time_units) if not np.isnan(x)
-            else np.timedelta64(0, self.time_units)
-        )
+            lambda x: np.timedelta64(int(x), self.time_units)
+            if not np.isnan(x) else np.timedelta64(0, self.time_units))
 
         data.index += offset
 

--- a/src/pytesmo/validation_framework/adapters.py
+++ b/src/pytesmo/validation_framework/adapters.py
@@ -628,6 +628,10 @@ class TimestampAdapter(BasicAdapter):
         """
         data = super()._adapt(data)
 
+        # Make sure the dataframes contains values
+        if data.empty:
+            return data
+
         # Get the generic time array
         if self.generic_time_field is not None:
             generic_time = data[self.generic_time_field]

--- a/tests/test_validation_framework/test_adapters.py
+++ b/tests/test_validation_framework/test_adapters.py
@@ -381,26 +381,20 @@ def test_timestamp_adapter():
     # The original should be returned
     pd.testing.assert_frame_equal(origin, adapted)
 
-    adapted_ds = TimestampAdapter(
-        ds,
-        time_offset_fields="offset",
-        time_units="s",
-        handle_invalid="return_null")
-    adapted = adapted_ds.read()
+    # test empty Dataframe
+    # -----------------------
 
-    # The empty dataframe should be returned with dropped time fields
-    assert adapted.empty
-    assert adapted.columns == ["sm"]
+    def _read_empty():
+        return pd.DataFrame(columns=["sm", "offset"],)
+
+    setattr(ds, "read", _read_empty)
+    origin = ds.read()
 
     adapted_ds = TimestampAdapter(
-        ds,
-        time_offset_fields="offset",
-        time_units="s",
-        handle_invalid="return_null",
-        drop_original=False)
+        ds, time_offset_fields="offset", time_units="s")
     adapted = adapted_ds.read()
 
-    # The original but empty dataframe should be returned
+    # The original should be returned
     assert adapted.empty
     assert (adapted.columns == ["sm", "offset"]).all()
 

--- a/tests/test_validation_framework/test_adapters.py
+++ b/tests/test_validation_framework/test_adapters.py
@@ -358,8 +358,8 @@ def test_timestamp_adapter():
 
     # Complex case
     # ================
-    generic_time = np.arange(100, 200)
-    index = generic_time.copy()
+    base_time = np.arange(100, 200)
+    index = base_time.copy()
     sm_var = np.random.randn(*index.shape)
     time_offset_field_min = np.random.normal(
         loc=40.0, scale=1.0, size=index.shape).astype(int)
@@ -369,10 +369,10 @@ def test_timestamp_adapter():
     def _read_complex():
         return pd.DataFrame(
             data=np.array([
-                sm_var, generic_time, time_offset_field_min,
+                sm_var, base_time, time_offset_field_min,
                 time_offset_field_sec
             ]).transpose(),
-            columns=["sm", "generic_time", "offset_min", "offset_sec"],
+            columns=["sm", "base_time", "offset_min", "offset_sec"],
             index=index)
 
     setattr(ds, "read", _read_complex)
@@ -382,14 +382,14 @@ def test_timestamp_adapter():
         ds,
         time_offset_fields=["offset_min", "offset_sec"],
         time_units=["m", "s"],
-        generic_time_field="generic_time",
-        generic_time_reference="2005-02-01")
+        base_time_field="base_time",
+        base_time_reference="2005-02-01")
 
     adapted = adapted_ds.read()
 
     should_be = origin.apply(
         lambda row: np.datetime64("2005-02-01") + np.timedelta64(
-            int(row["generic_time"]), "D") + np.timedelta64(
+            int(row["base_time"]), "D") + np.timedelta64(
                 int(row["offset_min"]), "m") + np.timedelta64(
                     int(row["offset_sec"]), "s"),
         axis=1).values

--- a/tests/test_validation_framework/test_adapters.py
+++ b/tests/test_validation_framework/test_adapters.py
@@ -324,7 +324,8 @@ def test_timestamp_adapter():
         ds,
         time_offset_fields="offset",
         time_units="s",
-        replace_index="exact_timestamp")
+        replace_index=False,
+        output_field="exact_timestamp")
     adapted = adapted_ds.read()
     assert (adapted.columns == ["sm", "exact_timestamp"]).all()
 

--- a/tests/test_validation_framework/test_adapters.py
+++ b/tests/test_validation_framework/test_adapters.py
@@ -302,5 +302,5 @@ def test_timestamp_adapter():
     adapted_ds = TimestampAdapter(ds, time_offset_field="offset", time_units="m")
     adapted = adapted_ds.read()
 
-    # The offset is expressed in seconds
+    # The offset is expressed in minutes
     assert origin.index[0] + np.timedelta64(time_offset_field[0], "m") == adapted.index[0]


### PR DESCRIPTION
Added a timestamp adapter for datasets that are read with an index in midnight UTC units and an additional field with the time offset. The adapter returns the original fields with the exact observation timestamp.

Applicable for instance to:

- SMOS L3
- SMAP L3
- C3S
- CCI