### PR TITLE
Ignore nans masking

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     - pynetcf
     - pygeogrids
     - pynetcf
-    - pygeobase
+    - pygeobase==0.4.0
     - more_itertools
     - build
     - repurpose

--- a/src/pytesmo/validation_framework/adapters.py
+++ b/src/pytesmo/validation_framework/adapters.py
@@ -91,8 +91,8 @@ class BasicAdapter:
 
     def __get_dataframe(self, data):
         if ((not isinstance(data, DataFrame)) and
-            (hasattr(data, self.data_property_name)) and
-            (isinstance(getattr(data, self.data_property_name), DataFrame))):
+                (hasattr(data, self.data_property_name)) and
+                (isinstance(getattr(data, self.data_property_name), DataFrame))):
             data = getattr(data, self.data_property_name)
         return data
 
@@ -290,13 +290,18 @@ class AdvancedMaskingAdapter(BasicAdapter):
         The output of this method will be changed by the adapter.
         If None is passed, only data from `read` and `read_ts` of cls
         will be adapted.
+    ignore_nans: bool, optional (default: False)
+        Should be set to True in case the NaNs in the mask field(s) should
+        be ignored, i.e. the main field should not be masked when NaNs
+        are present elswehere in the row
     """
 
-    def __init__(self, cls, filter_list, **kwargs):
+    def __init__(self, cls, filter_list, ignore_nans: bool = False, **kwargs):
 
         super().__init__(cls, **kwargs)
 
         self.filter_list = filter_list
+        self.ignore_nans = ignore_nans
 
     def _adapt(self, data):
         data = super()._adapt(data)
@@ -309,14 +314,17 @@ class AdvancedMaskingAdapter(BasicAdapter):
             else:
                 raise ValueError('"{}" is not a valid operator'.format(op))
 
-            new_mask = operator(data[column_name], threshold)
+            if self.ignore_nans:
+                new_mask = operator(data[column_name], threshold) | np.isnan(data[column_name])
+            else:
+                new_mask = operator(data[column_name], threshold)
 
             if mask is not None:
                 mask = mask & new_mask
             else:
                 mask = new_mask
 
-        return data[mask]
+        return data[mask].dropna(how="all")
 
 
 class AnomalyAdapter(BasicAdapter):
@@ -448,13 +456,13 @@ class ColumnCombineAdapter(BasicAdapter):
     """
 
     def __init__(
-        self,
-        cls,
-        func,
-        func_kwargs=None,
-        columns=None,
-        new_name="merged",
-        **kwargs,
+            self,
+            cls,
+            func,
+            func_kwargs=None,
+            columns=None,
+            new_name="merged",
+            **kwargs,
     ):
         """
         Parameters

--- a/src/pytesmo/validation_framework/adapters.py
+++ b/src/pytesmo/validation_framework/adapters.py
@@ -91,8 +91,8 @@ class BasicAdapter:
 
     def __get_dataframe(self, data):
         if ((not isinstance(data, DataFrame)) and
-                (hasattr(data, self.data_property_name)) and
-                (isinstance(getattr(data, self.data_property_name), DataFrame))):
+            (hasattr(data, self.data_property_name)) and
+            (isinstance(getattr(data, self.data_property_name), DataFrame))):
             data = getattr(data, self.data_property_name)
         return data
 
@@ -315,7 +315,8 @@ class AdvancedMaskingAdapter(BasicAdapter):
                 raise ValueError('"{}" is not a valid operator'.format(op))
 
             if self.ignore_nans:
-                new_mask = operator(data[column_name], threshold) | np.isnan(data[column_name])
+                new_mask = operator(data[column_name], threshold) | np.isnan(
+                    data[column_name])
             else:
                 new_mask = operator(data[column_name], threshold)
 
@@ -456,13 +457,13 @@ class ColumnCombineAdapter(BasicAdapter):
     """
 
     def __init__(
-            self,
-            cls,
-            func,
-            func_kwargs=None,
-            columns=None,
-            new_name="merged",
-            **kwargs,
+        self,
+        cls,
+        func,
+        func_kwargs=None,
+        columns=None,
+        new_name="merged",
+        **kwargs,
     ):
         """
         Parameters

--- a/tests/test_validation_framework/test_adapters.py
+++ b/tests/test_validation_framework/test_adapters.py
@@ -155,16 +155,6 @@ def test_advanced_masking_adapter_nans_ignored():
     nptest.assert_almost_equal(data_masked["y"].values, ref_y)
     nptest.assert_almost_equal(data_masked2["y"].values, ref_y)
 
-    # 9 is not a valid operator, should raise an exception
-    with pytest.raises(ValueError):
-        ds_mask = AdvancedMaskingAdapter(
-            ds,
-            [
-                ("x", 9, 5),
-            ],
-        )
-        data_masked = ds_mask.read_ts()
-
 
 def test_anomaly_adapter():
     ds = TestDataset("", n=20)

--- a/tests/test_validation_framework/test_adapters.py
+++ b/tests/test_validation_framework/test_adapters.py
@@ -1,7 +1,6 @@
 import pytest
 
 from src.pytesmo.validation_framework.adapters import TimestampAdapter
-
 """
 Test for the adapters.
 """
@@ -110,7 +109,9 @@ def test_advanced_masking_adapter_nans_ignored():
     ts = ds.read()
     ts.iloc[7]["x"] = np.nan
 
-    def _read(): return ts
+    def _read():
+        return ts
+
     setattr(ds, "read", _read)
 
     # the NaN in the flag field (x) is filtered out normally
@@ -146,7 +147,7 @@ def test_advanced_masking_adapter_nans_ignored():
     data_masked = ds_mask.read_ts()
     data_masked2 = ds_mask.read()
 
-    ref_x = np.array([ 5.,  6., np.nan,  8.,  9., 10., 11., 12., 13., 14.])
+    ref_x = np.array([5., 6., np.nan, 8., 9., 10., 11., 12., 13., 14.])
     ref_y = np.arange(5, 15) * 0.5
 
     nptest.assert_almost_equal(data_masked["x"].values, ref_x)
@@ -204,6 +205,7 @@ def test_anomaly_clim_adapter_one_column():
 
 
 def test_adapters_custom_fct_name():
+
     def assert_all_read_fcts(reader):
         assert (np.all(reader.read() == reader.read_ts()))
         assert (np.all(reader.read() == reader.alias_read()))
@@ -461,7 +463,7 @@ def test_timestamp_adapter():
     # -----------------------
 
     def _read_empty():
-        return pd.DataFrame(columns=["sm", "offset"], )
+        return pd.DataFrame(columns=["sm", "offset"],)
 
     setattr(ds, "read", _read_empty)
     origin = ds.read()
@@ -507,8 +509,8 @@ def test_timestamp_adapter():
     should_be = origin.apply(
         lambda row: np.datetime64("2005-02-01") + np.timedelta64(
             int(row["base_time"]), "D") + np.timedelta64(
-            int(row["offset_min"]), "m") + np.timedelta64(
-            int(row["offset_sec"]), "s"),
+                int(row["offset_min"]), "m") + np.timedelta64(
+                    int(row["offset_sec"]), "s"),
         axis=1).values
 
     assert (adapted.index.values == should_be).all()


### PR DESCRIPTION
Method for masking to ignore NaNs in filter columns, i.e. observations can be kept if no information is given by the filtering field.