### PR TITLE
Bugfix SubsetsMetricsAdapter #313

### DIFF
--- a/src/pytesmo/validation_framework/metric_calculators_adapters.py
+++ b/src/pytesmo/validation_framework/metric_calculators_adapters.py
@@ -133,7 +133,7 @@ class SubsetsMetricsAdapter:
 
         for setname, distr in self.subsets.items():
             if len(data.index) == 0:
-                df = pd.DataFrame()
+                df = data
             else:
                 df = distr.select(data)
             ds = self.cls.calc_metrics(df, gpi_info=gpi_info)


### PR DESCRIPTION
Bugfix the SubsetsMetricsAdapter to prevent missing grid points for validation with triple collocation together with stability or intra-annual metrics